### PR TITLE
Mark com.google.code.findbugs:annotations provided

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -106,7 +106,7 @@ limitations under the License.
             <groupId>com.google.code.findbugs</groupId>
             <artifactId>annotations</artifactId>
             <version>3.0.1</version>
-            <scope>compile</scope>
+            <scope>provided</scope>
         </dependency>
 
         <!-- test dependencies -->


### PR DESCRIPTION
Rationale outlined in the commit message:

> This way the "annotations" dependency does not end up on the classpath of dependant projects, which is nice for projects that e.g. use the jsr305 module instead. Note that complete absence of the annotations from the classpath does not matter at runtime.

Related is ronmamo/reflections#69, though in this case `jsr305` is not a viable alternative due to the use of the `SuppressFBWarnings` annotation.
