### PR TITLE
Made generation of dynamic subclasses synchronized.

### DIFF
--- a/src/main/java/nl/jqno/equalsverifier/internal/Instantiator.java
+++ b/src/main/java/nl/jqno/equalsverifier/internal/Instantiator.java
@@ -84,7 +84,7 @@ public final class Instantiator<T> {
     }
 
     @SuppressWarnings("unchecked")
-    private static <S> Class<S> giveDynamicSubclass(Class<S> superclass) {
+    private static synchronized <S> Class<S> giveDynamicSubclass(Class<S> superclass) {
         boolean isSystemClass = superclass.getName().startsWith("java");
         String namePrefix = isSystemClass ? "$" : "";
         String name = namePrefix + superclass.getName() + "$$DynamicSubclass";


### PR DESCRIPTION
When I run test for equals and hashCode in parallel for multiple classes I can get an exception
`IllegalStateException: Cannot inject already loaded type: class package1.package2.package3.....RealClass$$DynamicSubclass`
