### PR TITLE
Add generics support for Guava Ranges

### DIFF
--- a/src/main/java/nl/jqno/equalsverifier/JavaApiPrefabValues.java
+++ b/src/main/java/nl/jqno/equalsverifier/JavaApiPrefabValues.java
@@ -273,7 +273,7 @@ public final class JavaApiPrefabValues {
     @SuppressWarnings({"unchecked", "rawtypes"})
     private void addJava8ApiClasses() {
         String optional = "java.util.Optional";
-        addFactory(classForName(optional), new ReflectiveGenericContainerFactory(optional));
+        addFactory(classForName(optional), new ReflectiveGenericContainerFactory(optional, "of", Object.class));
 
         ConditionalInstantiator zoneId = new ConditionalInstantiator("java.time.ZoneId");
         addValues(zoneId.resolve(),
@@ -385,13 +385,12 @@ public final class JavaApiPrefabValues {
 
     @SuppressWarnings({"unchecked", "rawtypes"})
     private void addNewGoogleGuavaClasses() {
-        ConditionalInstantiator range = new ConditionalInstantiator(GUAVA_PACKAGE + "Range", false);
-        addValues(range.resolve(),
-                range.callFactory("open", classes(Comparable.class, Comparable.class), objects(1, 2)),
-                range.callFactory("open", classes(Comparable.class, Comparable.class), objects(3, 4)));
+        String rangeFqcn = GUAVA_PACKAGE + "Range";
+        ConditionalInstantiator range = new ConditionalInstantiator(rangeFqcn, false);
+        addFactory(range.resolve(), new ReflectiveGenericContainerFactory(rangeFqcn, "atLeast", Comparable.class));
 
         String optional = "com.google.common.base.Optional";
-        addFactory(classForName(optional), new ReflectiveGenericContainerFactory(optional));
+        addFactory(classForName(optional), new ReflectiveGenericContainerFactory(optional, "of", Object.class));
     }
 
     private void addJodaTimeClasses() {

--- a/src/main/java/nl/jqno/equalsverifier/internal/prefabvalues/factories/ReflectiveGenericContainerFactory.java
+++ b/src/main/java/nl/jqno/equalsverifier/internal/prefabvalues/factories/ReflectiveGenericContainerFactory.java
@@ -31,19 +31,28 @@ import static nl.jqno.equalsverifier.internal.Util.objects;
  */
 public class ReflectiveGenericContainerFactory<T> extends AbstractReflectiveGenericFactory<T> {
     private final String typeName;
+    private final String factoryMethod;
+    private final Class<?> parameterType;
 
-    public ReflectiveGenericContainerFactory(String typeName) {
+    public ReflectiveGenericContainerFactory(String typeName, String factoryMethod, final Class<?> parameterType) {
         this.typeName = typeName;
+        this.factoryMethod = factoryMethod;
+        this.parameterType = parameterType;
     }
 
     @Override
     public Tuple<T> createValues(TypeTag tag, PrefabValues prefabValues, LinkedHashSet<TypeTag> typeStack) {
         TypeTag internalTag = determineActualTypeTagFor(0, tag);
-        Object red = new ConditionalInstantiator(typeName)
-                .callFactory("of", classes(Object.class), objects(prefabValues.giveRed(internalTag)));
-        Object black = new ConditionalInstantiator(typeName)
-                .callFactory("of", classes(Object.class), objects(prefabValues.giveBlack(internalTag)));
+
+        Object red = createWith(prefabValues.giveRed(internalTag));
+        Object black = createWith(prefabValues.giveBlack(internalTag));
 
         return Tuple.of(red, black);
+    }
+
+    @SuppressWarnings("rawtypes")
+    private Object createWith(Object value) {
+        ConditionalInstantiator ci = new ConditionalInstantiator(typeName);
+        return ci.callFactory(factoryMethod, classes(parameterType), objects(value));
     }
 }

--- a/src/test/java/nl/jqno/equalsverifier/integration/extended_contract/ExternalApiClassesTest.java
+++ b/src/test/java/nl/jqno/equalsverifier/integration/extended_contract/ExternalApiClassesTest.java
@@ -22,6 +22,7 @@ import org.joda.time.*;
 import org.junit.Test;
 
 import javax.naming.Reference;
+import java.math.BigDecimal;
 
 import static nl.jqno.equalsverifier.testhelpers.Util.defaultEquals;
 import static nl.jqno.equalsverifier.testhelpers.Util.defaultHashCode;
@@ -194,13 +195,13 @@ public class ExternalApiClassesTest {
     static final class GuavaRegularCollectionsContainer {
         private final EvictingQueue<?> evictingQueue;
         private final MinMaxPriorityQueue<?> minMaxPriorityQueue;
-        private final RangeSet<?> rangeSet;
-        private final ImmutableRangeSet<?> immutableRangeSet;
-        private final TreeRangeSet<?> treeRangeSet;
+        private final RangeSet<Instant> rangeSet;
+        private final ImmutableRangeSet<String> immutableRangeSet;
+        private final TreeRangeSet<BigDecimal> treeRangeSet;
 
         // CHECKSTYLE: ignore ParameterNumber for 1 line.
         public GuavaRegularCollectionsContainer(EvictingQueue<?> evictingQueue, MinMaxPriorityQueue<?> minMaxPriorityQueue,
-                RangeSet<?> rangeSet, ImmutableRangeSet<?> immutableRangeSet, TreeRangeSet<?> treeRangeSet) {
+                RangeSet<Instant> rangeSet, ImmutableRangeSet<String> immutableRangeSet, TreeRangeSet<BigDecimal> treeRangeSet) {
             this.evictingQueue = evictingQueue; this.minMaxPriorityQueue = minMaxPriorityQueue;
             this.rangeSet = rangeSet; this.immutableRangeSet = immutableRangeSet; this.treeRangeSet = treeRangeSet;
         }
@@ -233,11 +234,11 @@ public class ExternalApiClassesTest {
 
     @SuppressWarnings("unused") // because of the use of defaultEquals and defaultHashCode
     static final class GuavaOtherContainer {
-        private final Range<?> range;
+        private final Range<Integer> range;
         private final Optional<?> optional;
 
         // CHECKSTYLE: ignore ParameterNumber for 1 line.
-        public GuavaOtherContainer(Range<?> range, Optional<?> optional) {
+        public GuavaOtherContainer(Range<Integer> range, Optional<?> optional) {
             this.range = range; this.optional = optional;
         }
 

--- a/src/test/java/nl/jqno/equalsverifier/internal/prefabvalues/factories/ReflectiveGenericContainerFactoryTest.java
+++ b/src/test/java/nl/jqno/equalsverifier/internal/prefabvalues/factories/ReflectiveGenericContainerFactoryTest.java
@@ -37,7 +37,7 @@ public class ReflectiveGenericContainerFactoryTest {
     private static final TypeTag RAWMAP_TYPETAG = new TypeTag(Map.class);
 
     private static final ReflectiveGenericContainerFactory<Optional> OPTIONAL_FACTORY =
-            new ReflectiveGenericContainerFactory<>("com.google.common.base.Optional");
+            new ReflectiveGenericContainerFactory<>("com.google.common.base.Optional", "of", Object.class);
 
     private final PrefabValues prefabValues = new PrefabValues();
     private final LinkedHashSet<TypeTag> typeStack = new LinkedHashSet<>();


### PR DESCRIPTION
# What problem does this pull request solve?

EqualsVerifier provides two prefab `Range` instances: `Range.open(1, 2)` and `Range.open(3, 4)`. That is, the generic type parameter to `Range<C extends Comparable>` is ignored and `Integer` is always used. This PR adds support for ranges over arbitrary types.
# Please provide any additional information below.

The commit message summarizes the changes:

```
Respect generic type parameters for Guava Ranges

Changes:
- Generalize the ReflectiveGenericContainerFactory so that one may specify the 
  signature of the method using which single-element containers are created.
- Replace the two prefab values `Range.open(1, 2)` and `Range.open(3, 4)` with
  instances created using `Range#atLeast(T)`.
- Update `ExternalApiClassesTest` to accommodate the changes. (The generic type
  parameters to `Range<?>`, `RangeSet<?>`, `ImmutableRangeSet<?>` and 
  `TreeRangeSet<?>` must now be fixed to `Comparable` types, because
  `Range#atLeast` does not accept arbitrary objects.)
```

Open questions:
1. Are you okay with the change to `ReflectiveGenericContainerFactory`?
2. Are you okay with the change to the "type" of `Range`s produced? (From `Range#open(Integer, Integer)` to `Range#atLeast(T)`.)
3. Would you like to see additional tests? If so, where?
