### PR TITLE
Generate distinct singleton enum collections

### DIFF
--- a/src/main/java/nl/jqno/equalsverifier/internal/prefabvalues/factories/CollectionFactory.java
+++ b/src/main/java/nl/jqno/equalsverifier/internal/prefabvalues/factories/CollectionFactory.java
@@ -36,9 +36,14 @@ public abstract class CollectionFactory<T extends Collection> extends AbstractRe
         TypeTag entryTag = determineAndCacheActualTypeTag(0, tag, prefabValues, clone);
 
         T red = createEmpty();
-        red.add(prefabValues.giveRed(entryTag));
+        Object redElem = prefabValues.giveRed(entryTag);
+        red.add(redElem);
+
         T black = createEmpty();
-        black.add(prefabValues.giveBlack(entryTag));
+        Object blackElem = prefabValues.giveBlack(entryTag);
+        if (!redElem.equals(blackElem)) {
+            black.add(blackElem);
+        }
 
         return new Tuple<>(red, black);
     }

--- a/src/test/java/nl/jqno/equalsverifier/internal/prefabvalues/factories/CollectionFactoryTest.java
+++ b/src/test/java/nl/jqno/equalsverifier/internal/prefabvalues/factories/CollectionFactoryTest.java
@@ -19,6 +19,7 @@ import nl.jqno.equalsverifier.JavaApiPrefabValues;
 import nl.jqno.equalsverifier.internal.prefabvalues.PrefabValues;
 import nl.jqno.equalsverifier.internal.prefabvalues.Tuple;
 import nl.jqno.equalsverifier.internal.prefabvalues.TypeTag;
+import nl.jqno.equalsverifier.testhelpers.types.TypeHelper.OneElementEnum;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -34,6 +35,8 @@ public class CollectionFactoryTest {
     private static final TypeTag OBJECT_TYPETAG = new TypeTag(Object.class);
     private static final TypeTag WILDCARDLIST_TYPETAG = new TypeTag(List.class, OBJECT_TYPETAG);
     private static final TypeTag RAWLIST_TYPETAG = new TypeTag(List.class);
+    private static final TypeTag ONEELEMENTENUM_TYPETAG = new TypeTag(OneElementEnum.class);
+    private static final TypeTag ONEELEMENTENUMSET_TYPETAG = new TypeTag(Set.class, ONEELEMENTENUM_TYPETAG);
 
     private static final CollectionFactory<List> LIST_FACTORY = new StubListPrefabValueFactory();
     private static final CollectionFactory<Set> SET_FACTORY = new StubSetPrefabValueFactory();
@@ -44,6 +47,7 @@ public class CollectionFactoryTest {
     private String black;
     private Object redObject;
     private Object blackObject;
+    private OneElementEnum redEnum;
 
     @Before
     public void setUp() {
@@ -52,6 +56,7 @@ public class CollectionFactoryTest {
         black = prefabValues.giveBlack(STRING_TYPETAG);
         redObject = prefabValues.giveRed(OBJECT_TYPETAG);
         blackObject = prefabValues.giveBlack(OBJECT_TYPETAG);
+        redEnum = prefabValues.giveBlack(ONEELEMENTENUM_TYPETAG);
     }
 
     @Test
@@ -80,6 +85,13 @@ public class CollectionFactoryTest {
         Tuple<List> tuple = LIST_FACTORY.createValues(RAWLIST_TYPETAG, prefabValues, typeStack);
         assertEquals(listOf(redObject), tuple.getRed());
         assertEquals(listOf(blackObject), tuple.getBlack());
+    }
+
+    @Test
+    public void createSetOfOneElementEnum() {
+        Tuple<Set> tuple = SET_FACTORY.createValues(ONEELEMENTENUMSET_TYPETAG, prefabValues, typeStack);
+        assertEquals(setOf(redEnum), tuple.getRed());
+        assertEquals(setOf(), tuple.getBlack());
     }
 
     private static class StubListPrefabValueFactory extends CollectionFactory<List> {


### PR DESCRIPTION
Currently, the following test fails:

``` java
public final class Test {
    @Immutable
    public static final class Dummy {
        public enum SingletonEnum {
            ELEM
        }

        private final ImmutableSet<SingletonEnum> values;

        Dummy(ImmutableSet<SingletonEnum> values) {
            this.values = values;
        }

        @Override
        public boolean equals(@Nullable final Object o) {
            return (o instanceof Dummy) && Objects.equals(this.values, ((Dummy) o).values);
        }

        @Override
        public int hashCode() {
            return Objects.hash(this.values);
        }
    }

    @Test
    public void testDummy() {
        EqualsVerifier.forClass(Dummy.class).verify();
    }
}
```

The error message is:

```
java.lang.AssertionError: Significant fields: equals does not use values, or it is stateless.
For more information, go to: http://www.jqno.nl/equalsverifier/errormessages
    at nl.jqno.equalsverifier.EqualsVerifier.handleError(EqualsVerifier.java:381)
    at nl.jqno.equalsverifier.EqualsVerifier.verify(EqualsVerifier.java:367)
    at com.example.Test.testDummy(TestTest.java:150)
    ...
```

This PR proposes a change which causes the test to pass, as it should. Interested to hear whether you think the approach taken is acceptable.
