### PR TITLE
171 chain with ignored fields

### DIFF
--- a/src/main/java/nl/jqno/equalsverifier/EqualsVerifier.java
+++ b/src/main/java/nl/jqno/equalsverifier/EqualsVerifier.java
@@ -196,14 +196,10 @@ public final class EqualsVerifier<T> {
     public EqualsVerifier<T> withOnlyTheseFields(String... fields) {
         checkIgnoredFields();
         List<String> ignoredFields = new ArrayList<>();
-        Set<String> specifiedFields = new HashSet<>(Arrays.asList(fields));
+        List<String> specifiedFields = Arrays.asList(fields);
         Set<String> actualFieldNames = config.getActualFields();
 
-        for (String field : specifiedFields) {
-            if (!actualFieldNames.contains(field)) {
-                throw new IllegalArgumentException("Class " + config.getType().getSimpleName() + " does not contain field " + field + ".");
-            }
-        }
+        validateFieldNamesExist(specifiedFields);
 
         for (String name: actualFieldNames) {
             if (!specifiedFields.contains(name)) {
@@ -341,10 +337,7 @@ public final class EqualsVerifier<T> {
     }
 
     private void validateFieldNamesExist(List<String> givenFields) {
-        Set<String> actualFieldNames = new HashSet<>();
-        for (Field field : FieldIterable.of(config.getType())) {
-            actualFieldNames.add(field.getName());
-        }
+        Set<String> actualFieldNames = config.getActualFields();
         for (String field : givenFields) {
             if (!actualFieldNames.contains(field)) {
                 throw new IllegalArgumentException("Class " + config.getType().getSimpleName() + " does not contain field " + field + ".");

--- a/src/main/java/nl/jqno/equalsverifier/EqualsVerifier.java
+++ b/src/main/java/nl/jqno/equalsverifier/EqualsVerifier.java
@@ -197,17 +197,17 @@ public final class EqualsVerifier<T> {
         checkIgnoredFields();
         List<String> ignoredFields = new ArrayList<>();
         Set<String> specifiedFields = new HashSet<>(Arrays.asList(fields));
-        Set<String> actualFieldNames = new HashSet<>();
-        for (Field f : FieldIterable.of(config.getType())) {
-            String name = f.getName();
-            actualFieldNames.add(name);
-            if (!specifiedFields.contains(name)) {
-                ignoredFields.add(name);
-            }
-        }
+        Set<String> actualFieldNames = config.getActualFields();
+
         for (String field : specifiedFields) {
             if (!actualFieldNames.contains(field)) {
                 throw new IllegalArgumentException("Class " + config.getType().getSimpleName() + " does not contain field " + field + ".");
+            }
+        }
+
+        for (String name: actualFieldNames) {
+            if (!specifiedFields.contains(name)) {
+                ignoredFields.add(name);
             }
         }
 

--- a/src/main/java/nl/jqno/equalsverifier/EqualsVerifier.java
+++ b/src/main/java/nl/jqno/equalsverifier/EqualsVerifier.java
@@ -118,7 +118,7 @@ public final class EqualsVerifier<T> {
         EnumSet<Warning> ws = config.getWarningsToSuppress();
         Collections.addAll(ws, warnings);
         config = config.withWarningsToSuppress(ws);
-        checkNonnullFields();
+        assertNoNonnullFields();
         return this;
     }
 
@@ -173,7 +173,7 @@ public final class EqualsVerifier<T> {
      * @return {@code this}, for easy method chaining.
      */
     public EqualsVerifier<T> withIgnoredFields(String... fields) {
-        checkNoExistingIncludedFields();
+        assertNoExistingIncludedFields();
         List<String> toBeExcludedFields = Arrays.asList(fields);
         validateFieldNamesExist(toBeExcludedFields);
 
@@ -194,7 +194,7 @@ public final class EqualsVerifier<T> {
      * @return {@code this}, for easy method chaining.
      */
     public EqualsVerifier<T> withOnlyTheseFields(String... fields) {
-        checkNoExistingExcludedFields();
+        assertNoExistingExcludedFields();
         List<String> specifiedFields = Arrays.asList(fields);
 
         validateFieldNamesExist(specifiedFields);
@@ -221,7 +221,7 @@ public final class EqualsVerifier<T> {
         List<String> nonnullFields = Arrays.asList(fields);
         validateFieldNamesExist(nonnullFields);
         config = config.withNonnullFields(nonnullFields);
-        checkNonnullFields();
+        assertNoNonnullFields();
         return this;
     }
 
@@ -318,20 +318,22 @@ public final class EqualsVerifier<T> {
         return this;
     }
 
-    private void checkNonnullFields() {
+    private void assertNoNonnullFields() {
         if (!config.getNonnullFields().isEmpty() && config.getWarningsToSuppress().contains(Warning.NULL_FIELDS)) {
             throw new IllegalArgumentException("You can call either withNonnullFields or suppress Warning.NULL_FIELDS, but not both.");
         }
     }
 
-    private void checkNoExistingExcludedFields() {
-        if (!config.getExcludedFields().isEmpty()) {
-            throw new IllegalArgumentException("You can call either withOnlyTheseFields or withIgnoredFields, but not both.");
-        }
+    private void assertNoExistingExcludedFields() {
+        assertNoExistingFields(config.getExcludedFields());
     }
 
-    private void checkNoExistingIncludedFields() {
-        if (!config.getIncludedFields().isEmpty()) {
+    private void assertNoExistingIncludedFields() {
+        assertNoExistingFields(config.getIncludedFields());
+    }
+
+    private void assertNoExistingFields(Set<String> fields) {
+        if (!fields.isEmpty()) {
             throw new IllegalArgumentException("You can call either withOnlyTheseFields or withIgnoredFields, but not both.");
         }
     }

--- a/src/main/java/nl/jqno/equalsverifier/internal/util/Configuration.java
+++ b/src/main/java/nl/jqno/equalsverifier/internal/util/Configuration.java
@@ -33,7 +33,6 @@ public final class Configuration<T> {
     private final Set<String> actualFields;
     private final Set<String> excludedFields;
     private final Set<String> includedFields;
-//    private final Set<String> ignoredFields;
     private final Set<String> nonnullFields;
     private final Set<String> ignoredAnnotations;
     private final CachedHashCodeInitializer<T> cachedHashCodeInitializer;
@@ -101,16 +100,38 @@ public final class Configuration<T> {
         return Collections.unmodifiableList(unequalExamples);
     }
 
-    public Configuration<T> withIgnoredFields(List<String> value) {
-        return new Configuration<>(type, prefabValues, equalExamples, unequalExamples, actualFields, new HashSet<>(value), includedFields, nonnullFields, ignoredAnnotations,
-                cachedHashCodeInitializer, hasRedefinedSuperclass, redefinedSubclass, usingGetClass, warningsToSuppress);
-    }
-
     public Set<String> getActualFields() {
         return Collections.unmodifiableSet(actualFields);
     }
 
+    public Set<String> getExcludedFields() {
+        return Collections.unmodifiableSet(excludedFields);
+    }
+
+    public Configuration<T> withExcludedFields(List<String> value) {
+        return new Configuration<>(type, prefabValues, equalExamples, unequalExamples, actualFields, new HashSet<>(value), includedFields, nonnullFields, ignoredAnnotations,
+                cachedHashCodeInitializer, hasRedefinedSuperclass, redefinedSubclass, usingGetClass, warningsToSuppress);
+    }
+
+    public Set<String> getIncludedFields() {
+        return Collections.unmodifiableSet(includedFields);
+    }
+
+    public Configuration<T> withIncludedFields(List<String> value) {
+        return new Configuration<>(type, prefabValues, equalExamples, unequalExamples, actualFields, excludedFields, new HashSet<>(value), nonnullFields, ignoredAnnotations,
+                cachedHashCodeInitializer, hasRedefinedSuperclass, redefinedSubclass, usingGetClass, warningsToSuppress);
+    }
+
     public Set<String> getIgnoredFields() {
+        Set<String> ignoredFields = new HashSet<>();
+        if (excludedFields.isEmpty() && !includedFields.isEmpty()) {
+            for (String name: actualFields) {
+                if (!includedFields.contains(name)) {
+                    ignoredFields.add(name);
+                }
+            }
+            return Collections.unmodifiableSet(ignoredFields);
+        }
         return Collections.unmodifiableSet(excludedFields);
     }
 

--- a/src/main/java/nl/jqno/equalsverifier/internal/util/Configuration.java
+++ b/src/main/java/nl/jqno/equalsverifier/internal/util/Configuration.java
@@ -128,16 +128,7 @@ public final class Configuration<T> {
     }
 
     public Set<String> getIgnoredFields() {
-        Set<String> ignoredFields = new HashSet<>();
-        if (excludedFields.isEmpty() && !includedFields.isEmpty()) {
-            for (String name: actualFields) {
-                if (!includedFields.contains(name)) {
-                    ignoredFields.add(name);
-                }
-            }
-            return Collections.unmodifiableSet(ignoredFields);
-        }
-        return Collections.unmodifiableSet(excludedFields);
+        return Collections.unmodifiableSet(includedFields.isEmpty() ? excludedFields : invertIncludedFields());
     }
 
     public Configuration<T> withNonnullFields(List<String> value) {
@@ -212,5 +203,15 @@ public final class Configuration<T> {
 
     public ClassAccessor<T> createClassAccessor() {
         return ClassAccessor.of(type, prefabValues, ignoredAnnotations, warningsToSuppress.contains(Warning.ANNOTATION));
+    }
+
+    private Set<String> invertIncludedFields() {
+        Set<String> ignoredFields = new HashSet<>();
+        for (String name: actualFields) {
+            if (!includedFields.contains(name)) {
+                ignoredFields.add(name);
+            }
+        }
+        return ignoredFields;
     }
 }

--- a/src/main/java/nl/jqno/equalsverifier/internal/util/Configuration.java
+++ b/src/main/java/nl/jqno/equalsverifier/internal/util/Configuration.java
@@ -43,7 +43,7 @@ public final class Configuration<T> {
 
     // CHECKSTYLE: ignore ParameterNumber for 1 line.
     private Configuration(Class<T> type, PrefabValues prefabValues, List<T> equalExamples, List<T> unequalExamples, Set<String> actualFields,
-                          Set<String> excludedFields,Set<String> includedFields, Set<String> nonnullFields, Set<String> ignoredAnnotations,
+                          Set<String> excludedFields, Set<String> includedFields, Set<String> nonnullFields, Set<String> ignoredAnnotations,
                           CachedHashCodeInitializer<T> cachedHashCodeInitializer, boolean hasRedefinedSuperclass,
                           Class<? extends T> redefinedSubclass, boolean usingGetClass, EnumSet<Warning> warningsToSuppress) {
 
@@ -65,8 +65,9 @@ public final class Configuration<T> {
     }
 
     public static <T> Configuration<T> of(Class<T> type) {
-        return new Configuration<>(type, new PrefabValues(), new ArrayList<T>(), new ArrayList<T>(), FieldNameExtractor.extractFieldNames(type), new HashSet<String>(),
-                new HashSet<String>(), new HashSet<String>(), new HashSet<String>(), CachedHashCodeInitializer.<T>passthrough(),
+        return new Configuration<>(type, new PrefabValues(), new ArrayList<T>(), new ArrayList<T>(),
+                FieldNameExtractor.extractFieldNames(type), new HashSet<String>(), new HashSet<String>(),
+                new HashSet<String>(), new HashSet<String>(), CachedHashCodeInitializer.<T>passthrough(),
                 false, null, false, EnumSet.noneOf(Warning.class));
     }
 
@@ -83,8 +84,9 @@ public final class Configuration<T> {
     }
 
     public Configuration<T> withEqualExamples(List<T> value) {
-        return new Configuration<>(type, prefabValues, value, unequalExamples, actualFields, excludedFields, includedFields, nonnullFields, ignoredAnnotations,
-                cachedHashCodeInitializer, hasRedefinedSuperclass, redefinedSubclass, usingGetClass, warningsToSuppress);
+        return new Configuration<>(type, prefabValues, value, unequalExamples, actualFields, excludedFields,
+                includedFields, nonnullFields, ignoredAnnotations, cachedHashCodeInitializer, hasRedefinedSuperclass,
+                redefinedSubclass, usingGetClass, warningsToSuppress);
     }
 
     public List<T> getEqualExamples() {
@@ -92,8 +94,9 @@ public final class Configuration<T> {
     }
 
     public Configuration<T> withUnequalExamples(List<T> value) {
-        return new Configuration<>(type, prefabValues, equalExamples, value, actualFields, excludedFields, includedFields, nonnullFields, ignoredAnnotations,
-                cachedHashCodeInitializer, hasRedefinedSuperclass, redefinedSubclass, usingGetClass, warningsToSuppress);
+        return new Configuration<>(type, prefabValues, equalExamples, value, actualFields, excludedFields,
+                includedFields, nonnullFields, ignoredAnnotations, cachedHashCodeInitializer, hasRedefinedSuperclass,
+                redefinedSubclass, usingGetClass, warningsToSuppress);
     }
 
     public List<T> getUnequalExamples() {
@@ -109,8 +112,9 @@ public final class Configuration<T> {
     }
 
     public Configuration<T> withExcludedFields(List<String> value) {
-        return new Configuration<>(type, prefabValues, equalExamples, unequalExamples, actualFields, new HashSet<>(value), includedFields, nonnullFields, ignoredAnnotations,
-                cachedHashCodeInitializer, hasRedefinedSuperclass, redefinedSubclass, usingGetClass, warningsToSuppress);
+        return new Configuration<>(type, prefabValues, equalExamples, unequalExamples, actualFields, new HashSet<>(value),
+                includedFields, nonnullFields, ignoredAnnotations, cachedHashCodeInitializer, hasRedefinedSuperclass,
+                redefinedSubclass, usingGetClass, warningsToSuppress);
     }
 
     public Set<String> getIncludedFields() {
@@ -118,8 +122,9 @@ public final class Configuration<T> {
     }
 
     public Configuration<T> withIncludedFields(List<String> value) {
-        return new Configuration<>(type, prefabValues, equalExamples, unequalExamples, actualFields, excludedFields, new HashSet<>(value), nonnullFields, ignoredAnnotations,
-                cachedHashCodeInitializer, hasRedefinedSuperclass, redefinedSubclass, usingGetClass, warningsToSuppress);
+        return new Configuration<>(type, prefabValues, equalExamples, unequalExamples, actualFields, excludedFields,
+                new HashSet<>(value), nonnullFields, ignoredAnnotations, cachedHashCodeInitializer, hasRedefinedSuperclass,
+                redefinedSubclass, usingGetClass, warningsToSuppress);
     }
 
     public Set<String> getIgnoredFields() {
@@ -136,8 +141,9 @@ public final class Configuration<T> {
     }
 
     public Configuration<T> withNonnullFields(List<String> value) {
-        return new Configuration<>(type, prefabValues, equalExamples, unequalExamples, actualFields, excludedFields, includedFields, new HashSet<>(value), ignoredAnnotations,
-                cachedHashCodeInitializer, hasRedefinedSuperclass, redefinedSubclass, usingGetClass, warningsToSuppress);
+        return new Configuration<>(type, prefabValues, equalExamples, unequalExamples, actualFields, excludedFields,
+                includedFields, new HashSet<>(value), ignoredAnnotations, cachedHashCodeInitializer, hasRedefinedSuperclass,
+                redefinedSubclass, usingGetClass, warningsToSuppress);
     }
 
     public Set<String> getNonnullFields() {
@@ -145,8 +151,9 @@ public final class Configuration<T> {
     }
 
     public Configuration<T> withIgnoredAnnotations(List<String> value) {
-        return new Configuration<>(type, prefabValues, equalExamples, unequalExamples, actualFields, excludedFields, includedFields, nonnullFields, new HashSet<>(value),
-                cachedHashCodeInitializer, hasRedefinedSuperclass, redefinedSubclass, usingGetClass, warningsToSuppress);
+        return new Configuration<>(type, prefabValues, equalExamples, unequalExamples, actualFields, excludedFields,
+                includedFields, nonnullFields, new HashSet<>(value), cachedHashCodeInitializer, hasRedefinedSuperclass,
+                redefinedSubclass, usingGetClass, warningsToSuppress);
     }
 
     public Set<String> getIgnoredAnnotations() {
@@ -154,8 +161,9 @@ public final class Configuration<T> {
     }
 
     public Configuration<T> withCachedHashCodeInitializer(CachedHashCodeInitializer<T> value) {
-        return new Configuration<>(type, prefabValues, equalExamples, unequalExamples, actualFields, excludedFields, includedFields, nonnullFields, ignoredAnnotations,
-                value, hasRedefinedSuperclass, redefinedSubclass, usingGetClass, warningsToSuppress);
+        return new Configuration<>(type, prefabValues, equalExamples, unequalExamples, actualFields, excludedFields,
+                includedFields, nonnullFields, ignoredAnnotations, value, hasRedefinedSuperclass,
+                redefinedSubclass, usingGetClass, warningsToSuppress);
     }
 
     public CachedHashCodeInitializer<T> getCachedHashCodeInitializer() {
@@ -163,8 +171,9 @@ public final class Configuration<T> {
     }
 
     public Configuration<T> withRedefinedSuperclass() {
-        return new Configuration<>(type, prefabValues, equalExamples, unequalExamples, actualFields, excludedFields, includedFields, nonnullFields, ignoredAnnotations,
-                cachedHashCodeInitializer, true, redefinedSubclass, usingGetClass, warningsToSuppress);
+        return new Configuration<>(type, prefabValues, equalExamples, unequalExamples, actualFields, excludedFields,
+                includedFields, nonnullFields, ignoredAnnotations, cachedHashCodeInitializer, true,
+                redefinedSubclass, usingGetClass, warningsToSuppress);
     }
 
     public boolean hasRedefinedSuperclass() {
@@ -172,8 +181,9 @@ public final class Configuration<T> {
     }
 
     public Configuration<T> withRedefinedSubclass(Class<? extends T> value) {
-        return new Configuration<>(type, prefabValues, equalExamples, unequalExamples, actualFields, excludedFields, includedFields, nonnullFields, ignoredAnnotations,
-                cachedHashCodeInitializer, hasRedefinedSuperclass, value, usingGetClass, warningsToSuppress);
+        return new Configuration<>(type, prefabValues, equalExamples, unequalExamples, actualFields, excludedFields,
+                includedFields, nonnullFields, ignoredAnnotations, cachedHashCodeInitializer, hasRedefinedSuperclass,
+                value, usingGetClass, warningsToSuppress);
     }
 
     public Class<? extends T> getRedefinedSubclass() {
@@ -181,8 +191,9 @@ public final class Configuration<T> {
     }
 
     public Configuration<T> withUsingGetClass() {
-        return new Configuration<>(type, prefabValues, equalExamples, unequalExamples, actualFields, excludedFields, includedFields, nonnullFields, ignoredAnnotations,
-                cachedHashCodeInitializer, hasRedefinedSuperclass, redefinedSubclass, true, warningsToSuppress);
+        return new Configuration<>(type, prefabValues, equalExamples, unequalExamples, actualFields, excludedFields,
+                includedFields, nonnullFields, ignoredAnnotations, cachedHashCodeInitializer, hasRedefinedSuperclass,
+                redefinedSubclass, true, warningsToSuppress);
     }
 
     public boolean isUsingGetClass() {
@@ -190,8 +201,9 @@ public final class Configuration<T> {
     }
 
     public Configuration<T> withWarningsToSuppress(EnumSet<Warning> value) {
-        return new Configuration<>(type, prefabValues, equalExamples, unequalExamples, actualFields, excludedFields, includedFields, nonnullFields, ignoredAnnotations,
-                cachedHashCodeInitializer, hasRedefinedSuperclass, redefinedSubclass, usingGetClass, value);
+        return new Configuration<>(type, prefabValues, equalExamples, unequalExamples, actualFields, excludedFields,
+                includedFields, nonnullFields, ignoredAnnotations, cachedHashCodeInitializer, hasRedefinedSuperclass,
+                redefinedSubclass, usingGetClass, value);
     }
 
     public EnumSet<Warning> getWarningsToSuppress() {

--- a/src/main/java/nl/jqno/equalsverifier/internal/util/Configuration.java
+++ b/src/main/java/nl/jqno/equalsverifier/internal/util/Configuration.java
@@ -30,6 +30,7 @@ public final class Configuration<T> {
     private final List<T> equalExamples;
     private final List<T> unequalExamples;
 
+    private final Set<String> actualFields;
     private final Set<String> ignoredFields;
     private final Set<String> nonnullFields;
     private final Set<String> ignoredAnnotations;
@@ -40,7 +41,7 @@ public final class Configuration<T> {
     private final EnumSet<Warning> warningsToSuppress;
 
     // CHECKSTYLE: ignore ParameterNumber for 1 line.
-    private Configuration(Class<T> type, PrefabValues prefabValues, List<T> equalExamples, List<T> unequalExamples,
+    private Configuration(Class<T> type, PrefabValues prefabValues, List<T> equalExamples, List<T> unequalExamples, Set<String> actualFields,
                           Set<String> ignoredFields, Set<String> nonnullFields, Set<String> ignoredAnnotations,
                           CachedHashCodeInitializer<T> cachedHashCodeInitializer, boolean hasRedefinedSuperclass,
                           Class<? extends T> redefinedSubclass, boolean usingGetClass, EnumSet<Warning> warningsToSuppress) {
@@ -50,6 +51,7 @@ public final class Configuration<T> {
         this.prefabValues = prefabValues;
         this.equalExamples = equalExamples;
         this.unequalExamples = unequalExamples;
+        this.actualFields = actualFields;
         this.ignoredFields = ignoredFields;
         this.nonnullFields = nonnullFields;
         this.ignoredAnnotations = ignoredAnnotations;
@@ -61,7 +63,7 @@ public final class Configuration<T> {
     }
 
     public static <T> Configuration<T> of(Class<T> type) {
-        return new Configuration<>(type, new PrefabValues(), new ArrayList<T>(), new ArrayList<T>(), new HashSet<String>(),
+        return new Configuration<>(type, new PrefabValues(), new ArrayList<T>(), new ArrayList<T>(), FieldNameExtractor.extractFields(type), new HashSet<String>(),
                 new HashSet<String>(), new HashSet<String>(), CachedHashCodeInitializer.<T>passthrough(),
                 false, null, false, EnumSet.noneOf(Warning.class));
     }
@@ -79,7 +81,7 @@ public final class Configuration<T> {
     }
 
     public Configuration<T> withEqualExamples(List<T> value) {
-        return new Configuration<>(type, prefabValues, value, unequalExamples, ignoredFields, nonnullFields, ignoredAnnotations,
+        return new Configuration<>(type, prefabValues, value, unequalExamples, actualFields, ignoredFields, nonnullFields, ignoredAnnotations,
                 cachedHashCodeInitializer, hasRedefinedSuperclass, redefinedSubclass, usingGetClass, warningsToSuppress);
     }
 
@@ -88,7 +90,7 @@ public final class Configuration<T> {
     }
 
     public Configuration<T> withUnequalExamples(List<T> value) {
-        return new Configuration<>(type, prefabValues, equalExamples, value, ignoredFields, nonnullFields, ignoredAnnotations,
+        return new Configuration<>(type, prefabValues, equalExamples, value, actualFields, ignoredFields, nonnullFields, ignoredAnnotations,
                 cachedHashCodeInitializer, hasRedefinedSuperclass, redefinedSubclass, usingGetClass, warningsToSuppress);
     }
 
@@ -97,17 +99,20 @@ public final class Configuration<T> {
     }
 
     public Configuration<T> withIgnoredFields(List<String> value) {
-        return new Configuration<>(type, prefabValues, equalExamples, unequalExamples, new HashSet<>(value), nonnullFields, ignoredAnnotations,
+        return new Configuration<>(type, prefabValues, equalExamples, unequalExamples, actualFields, new HashSet<>(value), nonnullFields, ignoredAnnotations,
                 cachedHashCodeInitializer, hasRedefinedSuperclass, redefinedSubclass, usingGetClass, warningsToSuppress);
     }
 
+    public Set<String> getActualFields() {
+        return Collections.unmodifiableSet(actualFields);
+    }
 
     public Set<String> getIgnoredFields() {
         return Collections.unmodifiableSet(ignoredFields);
     }
 
     public Configuration<T> withNonnullFields(List<String> value) {
-        return new Configuration<>(type, prefabValues, equalExamples, unequalExamples, ignoredFields, new HashSet<>(value), ignoredAnnotations,
+        return new Configuration<>(type, prefabValues, equalExamples, unequalExamples, actualFields, ignoredFields, new HashSet<>(value), ignoredAnnotations,
                 cachedHashCodeInitializer, hasRedefinedSuperclass, redefinedSubclass, usingGetClass, warningsToSuppress);
     }
 
@@ -116,7 +121,7 @@ public final class Configuration<T> {
     }
 
     public Configuration<T> withIgnoredAnnotations(List<String> value) {
-        return new Configuration<>(type, prefabValues, equalExamples, unequalExamples, ignoredFields, nonnullFields, new HashSet<>(value),
+        return new Configuration<>(type, prefabValues, equalExamples, unequalExamples, actualFields, ignoredFields, nonnullFields, new HashSet<>(value),
                 cachedHashCodeInitializer, hasRedefinedSuperclass, redefinedSubclass, usingGetClass, warningsToSuppress);
     }
 
@@ -125,7 +130,7 @@ public final class Configuration<T> {
     }
 
     public Configuration<T> withCachedHashCodeInitializer(CachedHashCodeInitializer<T> value) {
-        return new Configuration<>(type, prefabValues, equalExamples, unequalExamples, ignoredFields, nonnullFields, ignoredAnnotations,
+        return new Configuration<>(type, prefabValues, equalExamples, unequalExamples, actualFields, ignoredFields, nonnullFields, ignoredAnnotations,
                 value, hasRedefinedSuperclass, redefinedSubclass, usingGetClass, warningsToSuppress);
     }
 
@@ -134,7 +139,7 @@ public final class Configuration<T> {
     }
 
     public Configuration<T> withRedefinedSuperclass() {
-        return new Configuration<>(type, prefabValues, equalExamples, unequalExamples, ignoredFields, nonnullFields, ignoredAnnotations,
+        return new Configuration<>(type, prefabValues, equalExamples, unequalExamples, actualFields, ignoredFields, nonnullFields, ignoredAnnotations,
                 cachedHashCodeInitializer, true, redefinedSubclass, usingGetClass, warningsToSuppress);
     }
 
@@ -143,7 +148,7 @@ public final class Configuration<T> {
     }
 
     public Configuration<T> withRedefinedSubclass(Class<? extends T> value) {
-        return new Configuration<>(type, prefabValues, equalExamples, unequalExamples, ignoredFields, nonnullFields, ignoredAnnotations,
+        return new Configuration<>(type, prefabValues, equalExamples, unequalExamples, actualFields, ignoredFields, nonnullFields, ignoredAnnotations,
                 cachedHashCodeInitializer, hasRedefinedSuperclass, value, usingGetClass, warningsToSuppress);
     }
 
@@ -152,7 +157,7 @@ public final class Configuration<T> {
     }
 
     public Configuration<T> withUsingGetClass() {
-        return new Configuration<>(type, prefabValues, equalExamples, unequalExamples, ignoredFields, nonnullFields, ignoredAnnotations,
+        return new Configuration<>(type, prefabValues, equalExamples, unequalExamples, actualFields, ignoredFields, nonnullFields, ignoredAnnotations,
                 cachedHashCodeInitializer, hasRedefinedSuperclass, redefinedSubclass, true, warningsToSuppress);
     }
 
@@ -161,7 +166,7 @@ public final class Configuration<T> {
     }
 
     public Configuration<T> withWarningsToSuppress(EnumSet<Warning> value) {
-        return new Configuration<>(type, prefabValues, equalExamples, unequalExamples, ignoredFields, nonnullFields, ignoredAnnotations,
+        return new Configuration<>(type, prefabValues, equalExamples, unequalExamples, actualFields, ignoredFields, nonnullFields, ignoredAnnotations,
                 cachedHashCodeInitializer, hasRedefinedSuperclass, redefinedSubclass, usingGetClass, value);
     }
 

--- a/src/main/java/nl/jqno/equalsverifier/internal/util/Configuration.java
+++ b/src/main/java/nl/jqno/equalsverifier/internal/util/Configuration.java
@@ -31,7 +31,9 @@ public final class Configuration<T> {
     private final List<T> unequalExamples;
 
     private final Set<String> actualFields;
-    private final Set<String> ignoredFields;
+    private final Set<String> excludedFields;
+    private final Set<String> includedFields;
+//    private final Set<String> ignoredFields;
     private final Set<String> nonnullFields;
     private final Set<String> ignoredAnnotations;
     private final CachedHashCodeInitializer<T> cachedHashCodeInitializer;
@@ -42,7 +44,7 @@ public final class Configuration<T> {
 
     // CHECKSTYLE: ignore ParameterNumber for 1 line.
     private Configuration(Class<T> type, PrefabValues prefabValues, List<T> equalExamples, List<T> unequalExamples, Set<String> actualFields,
-                          Set<String> ignoredFields, Set<String> nonnullFields, Set<String> ignoredAnnotations,
+                          Set<String> excludedFields,Set<String> includedFields, Set<String> nonnullFields, Set<String> ignoredAnnotations,
                           CachedHashCodeInitializer<T> cachedHashCodeInitializer, boolean hasRedefinedSuperclass,
                           Class<? extends T> redefinedSubclass, boolean usingGetClass, EnumSet<Warning> warningsToSuppress) {
 
@@ -52,7 +54,8 @@ public final class Configuration<T> {
         this.equalExamples = equalExamples;
         this.unequalExamples = unequalExamples;
         this.actualFields = actualFields;
-        this.ignoredFields = ignoredFields;
+        this.excludedFields = excludedFields;
+        this.includedFields = includedFields;
         this.nonnullFields = nonnullFields;
         this.ignoredAnnotations = ignoredAnnotations;
         this.cachedHashCodeInitializer = cachedHashCodeInitializer;
@@ -64,7 +67,7 @@ public final class Configuration<T> {
 
     public static <T> Configuration<T> of(Class<T> type) {
         return new Configuration<>(type, new PrefabValues(), new ArrayList<T>(), new ArrayList<T>(), FieldNameExtractor.extractFields(type), new HashSet<String>(),
-                new HashSet<String>(), new HashSet<String>(), CachedHashCodeInitializer.<T>passthrough(),
+                new HashSet<String>(), new HashSet<String>(), new HashSet<String>(), CachedHashCodeInitializer.<T>passthrough(),
                 false, null, false, EnumSet.noneOf(Warning.class));
     }
 
@@ -81,7 +84,7 @@ public final class Configuration<T> {
     }
 
     public Configuration<T> withEqualExamples(List<T> value) {
-        return new Configuration<>(type, prefabValues, value, unequalExamples, actualFields, ignoredFields, nonnullFields, ignoredAnnotations,
+        return new Configuration<>(type, prefabValues, value, unequalExamples, actualFields, excludedFields, includedFields, nonnullFields, ignoredAnnotations,
                 cachedHashCodeInitializer, hasRedefinedSuperclass, redefinedSubclass, usingGetClass, warningsToSuppress);
     }
 
@@ -90,7 +93,7 @@ public final class Configuration<T> {
     }
 
     public Configuration<T> withUnequalExamples(List<T> value) {
-        return new Configuration<>(type, prefabValues, equalExamples, value, actualFields, ignoredFields, nonnullFields, ignoredAnnotations,
+        return new Configuration<>(type, prefabValues, equalExamples, value, actualFields, excludedFields, includedFields, nonnullFields, ignoredAnnotations,
                 cachedHashCodeInitializer, hasRedefinedSuperclass, redefinedSubclass, usingGetClass, warningsToSuppress);
     }
 
@@ -99,7 +102,7 @@ public final class Configuration<T> {
     }
 
     public Configuration<T> withIgnoredFields(List<String> value) {
-        return new Configuration<>(type, prefabValues, equalExamples, unequalExamples, actualFields, new HashSet<>(value), nonnullFields, ignoredAnnotations,
+        return new Configuration<>(type, prefabValues, equalExamples, unequalExamples, actualFields, new HashSet<>(value), includedFields, nonnullFields, ignoredAnnotations,
                 cachedHashCodeInitializer, hasRedefinedSuperclass, redefinedSubclass, usingGetClass, warningsToSuppress);
     }
 
@@ -108,11 +111,11 @@ public final class Configuration<T> {
     }
 
     public Set<String> getIgnoredFields() {
-        return Collections.unmodifiableSet(ignoredFields);
+        return Collections.unmodifiableSet(excludedFields);
     }
 
     public Configuration<T> withNonnullFields(List<String> value) {
-        return new Configuration<>(type, prefabValues, equalExamples, unequalExamples, actualFields, ignoredFields, new HashSet<>(value), ignoredAnnotations,
+        return new Configuration<>(type, prefabValues, equalExamples, unequalExamples, actualFields, excludedFields, includedFields, new HashSet<>(value), ignoredAnnotations,
                 cachedHashCodeInitializer, hasRedefinedSuperclass, redefinedSubclass, usingGetClass, warningsToSuppress);
     }
 
@@ -121,7 +124,7 @@ public final class Configuration<T> {
     }
 
     public Configuration<T> withIgnoredAnnotations(List<String> value) {
-        return new Configuration<>(type, prefabValues, equalExamples, unequalExamples, actualFields, ignoredFields, nonnullFields, new HashSet<>(value),
+        return new Configuration<>(type, prefabValues, equalExamples, unequalExamples, actualFields, excludedFields, includedFields, nonnullFields, new HashSet<>(value),
                 cachedHashCodeInitializer, hasRedefinedSuperclass, redefinedSubclass, usingGetClass, warningsToSuppress);
     }
 
@@ -130,7 +133,7 @@ public final class Configuration<T> {
     }
 
     public Configuration<T> withCachedHashCodeInitializer(CachedHashCodeInitializer<T> value) {
-        return new Configuration<>(type, prefabValues, equalExamples, unequalExamples, actualFields, ignoredFields, nonnullFields, ignoredAnnotations,
+        return new Configuration<>(type, prefabValues, equalExamples, unequalExamples, actualFields, excludedFields, includedFields, nonnullFields, ignoredAnnotations,
                 value, hasRedefinedSuperclass, redefinedSubclass, usingGetClass, warningsToSuppress);
     }
 
@@ -139,7 +142,7 @@ public final class Configuration<T> {
     }
 
     public Configuration<T> withRedefinedSuperclass() {
-        return new Configuration<>(type, prefabValues, equalExamples, unequalExamples, actualFields, ignoredFields, nonnullFields, ignoredAnnotations,
+        return new Configuration<>(type, prefabValues, equalExamples, unequalExamples, actualFields, excludedFields, includedFields, nonnullFields, ignoredAnnotations,
                 cachedHashCodeInitializer, true, redefinedSubclass, usingGetClass, warningsToSuppress);
     }
 
@@ -148,7 +151,7 @@ public final class Configuration<T> {
     }
 
     public Configuration<T> withRedefinedSubclass(Class<? extends T> value) {
-        return new Configuration<>(type, prefabValues, equalExamples, unequalExamples, actualFields, ignoredFields, nonnullFields, ignoredAnnotations,
+        return new Configuration<>(type, prefabValues, equalExamples, unequalExamples, actualFields, excludedFields, includedFields, nonnullFields, ignoredAnnotations,
                 cachedHashCodeInitializer, hasRedefinedSuperclass, value, usingGetClass, warningsToSuppress);
     }
 
@@ -157,7 +160,7 @@ public final class Configuration<T> {
     }
 
     public Configuration<T> withUsingGetClass() {
-        return new Configuration<>(type, prefabValues, equalExamples, unequalExamples, actualFields, ignoredFields, nonnullFields, ignoredAnnotations,
+        return new Configuration<>(type, prefabValues, equalExamples, unequalExamples, actualFields, excludedFields, includedFields, nonnullFields, ignoredAnnotations,
                 cachedHashCodeInitializer, hasRedefinedSuperclass, redefinedSubclass, true, warningsToSuppress);
     }
 
@@ -166,7 +169,7 @@ public final class Configuration<T> {
     }
 
     public Configuration<T> withWarningsToSuppress(EnumSet<Warning> value) {
-        return new Configuration<>(type, prefabValues, equalExamples, unequalExamples, actualFields, ignoredFields, nonnullFields, ignoredAnnotations,
+        return new Configuration<>(type, prefabValues, equalExamples, unequalExamples, actualFields, excludedFields, includedFields, nonnullFields, ignoredAnnotations,
                 cachedHashCodeInitializer, hasRedefinedSuperclass, redefinedSubclass, usingGetClass, value);
     }
 

--- a/src/main/java/nl/jqno/equalsverifier/internal/util/Configuration.java
+++ b/src/main/java/nl/jqno/equalsverifier/internal/util/Configuration.java
@@ -65,7 +65,7 @@ public final class Configuration<T> {
     }
 
     public static <T> Configuration<T> of(Class<T> type) {
-        return new Configuration<>(type, new PrefabValues(), new ArrayList<T>(), new ArrayList<T>(), FieldNameExtractor.extractFields(type), new HashSet<String>(),
+        return new Configuration<>(type, new PrefabValues(), new ArrayList<T>(), new ArrayList<T>(), FieldNameExtractor.extractFieldNames(type), new HashSet<String>(),
                 new HashSet<String>(), new HashSet<String>(), new HashSet<String>(), CachedHashCodeInitializer.<T>passthrough(),
                 false, null, false, EnumSet.noneOf(Warning.class));
     }

--- a/src/main/java/nl/jqno/equalsverifier/internal/util/FieldNameExtractor.java
+++ b/src/main/java/nl/jqno/equalsverifier/internal/util/FieldNameExtractor.java
@@ -1,13 +1,30 @@
+/*
+ * Copyright 2017 Jan Ouwens
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package nl.jqno.equalsverifier.internal.util;
+
+import nl.jqno.equalsverifier.internal.reflection.FieldIterable;
 
 import java.lang.reflect.Field;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
 
-import nl.jqno.equalsverifier.internal.reflection.FieldIterable;
+final class FieldNameExtractor {
 
-class FieldNameExtractor {
+    private FieldNameExtractor() {}
 
     static <T> Set<String> extractFieldNames(Class<T> type) {
         Set<String> actualFieldNames = new HashSet<>();

--- a/src/main/java/nl/jqno/equalsverifier/internal/util/FieldNameExtractor.java
+++ b/src/main/java/nl/jqno/equalsverifier/internal/util/FieldNameExtractor.java
@@ -9,8 +9,7 @@ import nl.jqno.equalsverifier.internal.reflection.FieldIterable;
 
 class FieldNameExtractor {
 
-    static Set<String> extractFields(Class type) {
-
+    static <T> Set<String> extractFieldNames(Class<T> type) {
         Set<String> actualFieldNames = new HashSet<>();
         for (Field f : FieldIterable.of(type)) {
             String name = f.getName();

--- a/src/main/java/nl/jqno/equalsverifier/internal/util/FieldNameExtractor.java
+++ b/src/main/java/nl/jqno/equalsverifier/internal/util/FieldNameExtractor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 Jan Ouwens
+ * Copyright 2017 Nathan Ragnar Bernard Perdijk
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/nl/jqno/equalsverifier/internal/util/FieldNameExtractor.java
+++ b/src/main/java/nl/jqno/equalsverifier/internal/util/FieldNameExtractor.java
@@ -1,14 +1,15 @@
 package nl.jqno.equalsverifier.internal.util;
 
 import java.lang.reflect.Field;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
 
 import nl.jqno.equalsverifier.internal.reflection.FieldIterable;
 
-public class FieldNameExtractor {
+class FieldNameExtractor {
 
-    public static Set<String> extractFields(Class type) {
+    static Set<String> extractFields(Class type) {
 
         Set<String> actualFieldNames = new HashSet<>();
         for (Field f : FieldIterable.of(type)) {
@@ -16,7 +17,7 @@ public class FieldNameExtractor {
             actualFieldNames.add(name);
         }
 
-        return actualFieldNames;
+        return Collections.unmodifiableSet(actualFieldNames);
     }
 
 }

--- a/src/main/java/nl/jqno/equalsverifier/internal/util/FieldNameExtractor.java
+++ b/src/main/java/nl/jqno/equalsverifier/internal/util/FieldNameExtractor.java
@@ -1,0 +1,22 @@
+package nl.jqno.equalsverifier.internal.util;
+
+import java.lang.reflect.Field;
+import java.util.HashSet;
+import java.util.Set;
+
+import nl.jqno.equalsverifier.internal.reflection.FieldIterable;
+
+public class FieldNameExtractor {
+
+    public static Set<String> extractFields(Class type) {
+
+        Set<String> actualFieldNames = new HashSet<>();
+        for (Field f : FieldIterable.of(type)) {
+            String name = f.getName();
+            actualFieldNames.add(name);
+        }
+
+        return actualFieldNames;
+    }
+
+}

--- a/src/test/java/nl/jqno/equalsverifier/integration/extended_contract/SignificantFieldsTest.java
+++ b/src/test/java/nl/jqno/equalsverifier/integration/extended_contract/SignificantFieldsTest.java
@@ -163,6 +163,31 @@ public class SignificantFieldsTest extends IntegrationTestBase {
     }
 
     @Test
+    public void succeed_repeating_withIgnoredFields_givenAllFieldsShouldBeUsedExceptThoseTwo() {
+        EqualsVerifier.forClass(TwoFieldsUnusedColorPoint.class)
+                .withIgnoredFields("colorNotUsed")
+                .withIgnoredFields("colorAlsoNotUsed")
+                .verify();
+    }
+
+    @Test
+    public void succeed_repeating_withOnlyTheseFields_givenAllFieldsShouldBeUsedExceptThoseTwo() {
+        EqualsVerifier.forClass(OneFieldUnused.class)
+                .withOnlyTheseFields("x")
+                .withOnlyTheseFields("y")
+                .verify();
+    }
+
+    @Test
+    public void fail_combining_withOnlyTheseFields_and_withIgnoredFields() {
+        expectException(IllegalArgumentException.class, "You can call either withOnlyTheseFields or withIgnoredFields, but not both.");
+        EqualsVerifier.forClass(OneFieldUnused.class)
+                .withOnlyTheseFields("x")
+                .withIgnoredFields("colorNotUsed")
+                .verify();
+    }
+
+    @Test
     public void fail_whenTwoFieldsAreUnUsed_givenAllFieldsShouldBeUsedExceptOneOfThemButNotBoth() {
         expectFailure("Significant fields", "equals does not use", "colorAlsoNotUsed");
         EqualsVerifier.forClass(TwoFieldsUnusedColorPoint.class)

--- a/src/test/java/nl/jqno/equalsverifier/integration/extended_contract/SignificantFieldsTest.java
+++ b/src/test/java/nl/jqno/equalsverifier/integration/extended_contract/SignificantFieldsTest.java
@@ -182,7 +182,7 @@ public class SignificantFieldsTest extends IntegrationTestBase {
     public void fail_combining_withOnlyTheseFields_and_withIgnoredFields() {
         expectException(IllegalArgumentException.class, "You can call either withOnlyTheseFields or withIgnoredFields, but not both.");
         EqualsVerifier.forClass(OneFieldUnused.class)
-                .withOnlyTheseFields("x")
+                .withOnlyTheseFields("x", "y")
                 .withIgnoredFields("colorNotUsed")
                 .verify();
     }

--- a/src/test/java/nl/jqno/equalsverifier/integration/extended_contract/SignificantFieldsTest.java
+++ b/src/test/java/nl/jqno/equalsverifier/integration/extended_contract/SignificantFieldsTest.java
@@ -163,7 +163,7 @@ public class SignificantFieldsTest extends IntegrationTestBase {
     }
 
     @Test
-    public void succeed_repeating_withIgnoredFields_givenAllFieldsShouldBeUsedExceptThoseTwo() {
+    public void succeed_whenRepeatingWithIgnoredFields_givenAllFieldsShouldBeUsedExceptThoseTwo() {
         EqualsVerifier.forClass(TwoFieldsUnusedColorPoint.class)
                 .withIgnoredFields("colorNotUsed")
                 .withIgnoredFields("colorAlsoNotUsed")
@@ -171,7 +171,7 @@ public class SignificantFieldsTest extends IntegrationTestBase {
     }
 
     @Test
-    public void succeed_repeating_withOnlyTheseFields_givenAllFieldsShouldBeUsedExceptThoseTwo() {
+    public void succeed_whenRepeatingWithOnlyTheseFields_givenAllFieldsShouldBeUsedExceptThoseTwo() {
         EqualsVerifier.forClass(OneFieldUnused.class)
                 .withOnlyTheseFields("x")
                 .withOnlyTheseFields("y")
@@ -179,7 +179,7 @@ public class SignificantFieldsTest extends IntegrationTestBase {
     }
 
     @Test
-    public void fail_combining_withOnlyTheseFields_and_withIgnoredFields() {
+    public void fail_whenCombiningWithOnlyTheseFieldsAndWithIgnoredFields() {
         expectException(IllegalArgumentException.class, "You can call either withOnlyTheseFields or withIgnoredFields, but not both.");
         EqualsVerifier.forClass(OneFieldUnused.class)
                 .withOnlyTheseFields("x", "y")

--- a/src/test/java/nl/jqno/equalsverifier/internal/util/FieldNameExtractorTest.java
+++ b/src/test/java/nl/jqno/equalsverifier/internal/util/FieldNameExtractorTest.java
@@ -27,6 +27,20 @@ public class FieldNameExtractorTest {
         assertTrue("Total number of fields was not equal to expected value", 4 == fields.size());
     }
 
+    @Test(expected = UnsupportedOperationException.class)
+    public void should_disallow_adding_extra_fields() throws Exception {
+        Set<String> fields = FieldNameExtractor.extractFields(FieldNameExtractorTestHelper.class);
+
+        fields.add("illegally added field");
+    }
+
+    @Test(expected = UnsupportedOperationException.class)
+    public void should_disallow_removing_fields() throws Exception {
+        Set<String> fields = FieldNameExtractor.extractFields(FieldNameExtractorTestHelper.class);
+
+        fields.remove(FIELD_STRING);
+    }
+
 }
 
 

--- a/src/test/java/nl/jqno/equalsverifier/internal/util/FieldNameExtractorTest.java
+++ b/src/test/java/nl/jqno/equalsverifier/internal/util/FieldNameExtractorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 Jan Ouwens
+ * Copyright 2017 Nathan Ragnar Bernard Perdijk
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/nl/jqno/equalsverifier/internal/util/FieldNameExtractorTest.java
+++ b/src/test/java/nl/jqno/equalsverifier/internal/util/FieldNameExtractorTest.java
@@ -1,0 +1,52 @@
+package nl.jqno.equalsverifier.internal.util;
+
+import static org.junit.Assert.*;
+
+import java.util.List;
+import java.util.Set;
+
+import org.junit.Test;
+
+public class FieldNameExtractorTest {
+    private static final String FIELD_NOT_FOUND = "field not found: ";
+
+    private static final String FIELD_STRING = "fieldString";
+    private static final String FIELD_OBJECT = "fieldObject";
+    private static final String FIELD_LIST = "fieldList";
+    private static final String FIELD_PRIMITIVE_INT = "fieldPrimitiveInt";
+
+    @Test
+    public void should_extractFields_succesfully() throws Exception {
+        Set<String> fields = FieldNameExtractor.extractFields(FieldNameExtractorTestHelper.class);
+
+        assertTrue(FIELD_NOT_FOUND + FIELD_STRING, fields.contains(FIELD_STRING));
+        assertTrue(FIELD_NOT_FOUND + FIELD_OBJECT, fields.contains(FIELD_OBJECT));
+        assertTrue(FIELD_NOT_FOUND + FIELD_LIST, fields.contains(FIELD_LIST));
+        assertTrue(FIELD_NOT_FOUND + FIELD_PRIMITIVE_INT, fields.contains(FIELD_PRIMITIVE_INT));
+
+        assertTrue("Total number of fields was not equal to expected value", 4 == fields.size());
+    }
+
+}
+
+
+class FieldNameExtractorTestHelper {
+    public final String fieldString;
+    private final Object fieldObject;
+    final List<Integer> fieldList;
+    protected int fieldPrimitiveInt;
+
+    public FieldNameExtractorTestHelper(String fieldString, Object fieldObject, List<Integer> fieldList) {
+        this.fieldString = fieldString;
+        this.fieldObject = fieldObject;
+        this.fieldList = fieldList;
+    }
+
+    public int getFieldPrimitiveInt() {
+        return fieldPrimitiveInt;
+    }
+
+    public void setFieldPrimitiveInt(int fieldPrimitiveInt) {
+        this.fieldPrimitiveInt = fieldPrimitiveInt;
+    }
+}

--- a/src/test/java/nl/jqno/equalsverifier/internal/util/FieldNameExtractorTest.java
+++ b/src/test/java/nl/jqno/equalsverifier/internal/util/FieldNameExtractorTest.java
@@ -17,7 +17,7 @@ public class FieldNameExtractorTest {
 
     @Test
     public void should_extractFields_succesfully() throws Exception {
-        Set<String> fields = FieldNameExtractor.extractFields(FieldNameExtractorTestHelper.class);
+        Set<String> fields = FieldNameExtractor.extractFieldNames(FieldNameExtractorTestHelper.class);
 
         assertTrue(FIELD_NOT_FOUND + FIELD_STRING, fields.contains(FIELD_STRING));
         assertTrue(FIELD_NOT_FOUND + FIELD_OBJECT, fields.contains(FIELD_OBJECT));
@@ -29,14 +29,14 @@ public class FieldNameExtractorTest {
 
     @Test(expected = UnsupportedOperationException.class)
     public void should_disallow_adding_extra_fields() throws Exception {
-        Set<String> fields = FieldNameExtractor.extractFields(FieldNameExtractorTestHelper.class);
+        Set<String> fields = FieldNameExtractor.extractFieldNames(FieldNameExtractorTestHelper.class);
 
         fields.add("illegally added field");
     }
 
     @Test(expected = UnsupportedOperationException.class)
     public void should_disallow_removing_fields() throws Exception {
-        Set<String> fields = FieldNameExtractor.extractFields(FieldNameExtractorTestHelper.class);
+        Set<String> fields = FieldNameExtractor.extractFieldNames(FieldNameExtractorTestHelper.class);
 
         fields.remove(FIELD_STRING);
     }

--- a/src/test/java/nl/jqno/equalsverifier/internal/util/FieldNameExtractorTest.java
+++ b/src/test/java/nl/jqno/equalsverifier/internal/util/FieldNameExtractorTest.java
@@ -1,11 +1,26 @@
+/*
+ * Copyright 2017 Jan Ouwens
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package nl.jqno.equalsverifier.internal.util;
 
-import static org.junit.Assert.*;
+import org.junit.Test;
+
+import static org.junit.Assert.assertTrue;
 
 import java.util.List;
 import java.util.Set;
-
-import org.junit.Test;
 
 public class FieldNameExtractorTest {
     private static final String FIELD_NOT_FOUND = "field not found: ";
@@ -14,6 +29,7 @@ public class FieldNameExtractorTest {
     private static final String FIELD_OBJECT = "fieldObject";
     private static final String FIELD_LIST = "fieldList";
     private static final String FIELD_PRIMITIVE_INT = "fieldPrimitiveInt";
+
 
     @Test
     public void should_extractFields_succesfully() throws Exception {
@@ -41,26 +57,21 @@ public class FieldNameExtractorTest {
         fields.remove(FIELD_STRING);
     }
 
-}
+    class FieldNameExtractorTestHelper {
+        public final String fieldString;
+        protected int fieldPrimitiveInt;
+        final List<Integer> fieldList;
+        private final Object fieldObject;
 
+        public FieldNameExtractorTestHelper(String fieldString, List<Integer> fieldList, Object fieldObject) {
+            this.fieldString = fieldString;
+            this.fieldList = fieldList;
+            this.fieldObject = fieldObject;
+        }
 
-class FieldNameExtractorTestHelper {
-    public final String fieldString;
-    private final Object fieldObject;
-    final List<Integer> fieldList;
-    protected int fieldPrimitiveInt;
-
-    public FieldNameExtractorTestHelper(String fieldString, Object fieldObject, List<Integer> fieldList) {
-        this.fieldString = fieldString;
-        this.fieldObject = fieldObject;
-        this.fieldList = fieldList;
+        public void setFieldPrimitiveInt(int newInt) {
+            this.fieldPrimitiveInt = newInt;
+        }
     }
 
-    public int getFieldPrimitiveInt() {
-        return fieldPrimitiveInt;
-    }
-
-    public void setFieldPrimitiveInt(int fieldPrimitiveInt) {
-        this.fieldPrimitiveInt = fieldPrimitiveInt;
-    }
 }


### PR DESCRIPTION
# What problem does this pull request solve?
Fixes issue #171 where the user couldn't chain multiple calls to withOnlyTheseFields and withIgnoredFields and an incorrect error message would appear

# Please provide any additional information below.
Some mild refactoring to optimise the adding of ignored and expected fields.
Important: there are no warnings to signify the user has specified the same field twice (works as before).
Rest of the information on what has changed and why should be extractable from the commit messages. 👍 
