### PR TITLE
Include Maven coordinates in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,16 @@
 [![Open issues](https://img.shields.io/github/issues/jqno/equalsverifier.svg?style=plastic)](https://github.com/jqno/equalsverifier/issues)
 
 **EqualsVerifier** can be used in Java unit tests to verify whether the contract for the equals and hashCode methods in a class is met.
+The Maven coordinates are:
+
+```xml
+<dependency>
+    <groupId>nl.jqno.equalsverifier</groupId>
+    <artifactId>equalsverifier</artifactId>
+    <version>2.3.3</version>
+    <scope>test</scope>
+</dependency>
+```
 
 For documentation, please see the [project's website](http://www.jqno.nl/equalsverifier).
 


### PR DESCRIPTION
# What problem does this pull request solve?

I looked for Maven coordinates: GitHub ~> documentation ~> Manual ~> Getting Started. Took me too long. :wink:

# Please provide any additional information below.

This has the unfortunate site effect that it has to be updated with every new release because of the version.