### PR TITLE
Add prefab values for other java.time classes

### DIFF
--- a/src/main/java/nl/jqno/equalsverifier/internal/prefabvalues/JavaApiPrefabValues.java
+++ b/src/main/java/nl/jqno/equalsverifier/internal/prefabvalues/JavaApiPrefabValues.java
@@ -76,6 +76,7 @@ public final class JavaApiPrefabValues {
     private void addJavaClasses() {
         addPrimitiveClasses();
         addCommonClasses();
+        addDateTimeClasses();
         addUncommonClasses();
         addCollection();
         addLists();
@@ -131,36 +132,53 @@ public final class JavaApiPrefabValues {
     private void addCommonClasses() {
         addValues(BigDecimal.class, BigDecimal.ZERO, BigDecimal.ONE, BigDecimal.ZERO);
         addValues(BigInteger.class, BigInteger.ZERO, BigInteger.ONE, BigInteger.ZERO);
-        addValues(Calendar.class, new GregorianCalendar(2010, 7, 4), new GregorianCalendar(2010, 7, 5), new GregorianCalendar(2010, 7, 4));
-        addValues(Date.class, new Date(0), new Date(1), new Date(0));
-        addValues(DateFormat.class, DateFormat.getTimeInstance(), DateFormat.getDateInstance(), DateFormat.getTimeInstance());
-        addValues(DateTimeFormatter.class, DateTimeFormatter.ISO_TIME, DateTimeFormatter.ISO_DATE, DateTimeFormatter.ISO_TIME);
         addValues(File.class, new File(""), new File("/"), new File(""));
         addValues(Formatter.class, new Formatter(), new Formatter(), new Formatter());
-        addValues(GregorianCalendar.class, new GregorianCalendar(2010, 7, 4), new GregorianCalendar(2010, 7, 5), new GregorianCalendar(2010, 7, 4));
-        addValues(LocalDateTime.class, LocalDateTime.MIN, LocalDateTime.MAX, LocalDateTime.MIN);
-        addValues(LocalDate.class, LocalDate.MIN, LocalDate.MAX, LocalDate.MIN);
-        addValues(LocalTime.class, LocalTime.MIN, LocalTime.MAX, LocalTime.MIN);
         addValues(Locale.class, new Locale("nl"), new Locale("hu"), new Locale("nl"));
         addValues(Pattern.class, Pattern.compile("one"), Pattern.compile("two"), Pattern.compile("one"));
-        addValues(SimpleDateFormat.class, new SimpleDateFormat("yMd"), new SimpleDateFormat("dMy"), new SimpleDateFormat("yMd"));
         addValues(Scanner.class, new Scanner("one"), new Scanner("two"), new Scanner("one"));
         addValues(StampedLock.class, new StampedLock(), new StampedLock(), new StampedLock());
-        addValues(TimeZone.class, TimeZone.getTimeZone("GMT+1"), TimeZone.getTimeZone("GMT+2"), TimeZone.getTimeZone("GMT+1"));
         addValues(Thread.class, new Thread("one"), new Thread("two"), new Thread("one"));
         addValues(Throwable.class, new Throwable(), new Throwable(), new Throwable());
         addValues(URI.class, URI.create("x"), URI.create("y"), URI.create("x"));
         addValues(UUID.class, new UUID(0, -1), new UUID(1, 0), new UUID(0, -1));
+
+        addFactory(CompletableFuture.class, simple(ignored -> new CompletableFuture<>(), CompletableFuture::new));
+        addFactory(Optional.class, simple(Optional::of, Optional::empty));
+        addFactory(Supplier.class, simple(a -> () -> a, () -> () -> null));
+    }
+
+    private void addDateTimeClasses() {
+        addValues(Calendar.class, new GregorianCalendar(2010, 7, 4), new GregorianCalendar(2010, 7, 5), new GregorianCalendar(2010, 7, 4));
+        addValues(Date.class, new Date(0), new Date(1), new Date(0));
+        addValues(DateFormat.class, DateFormat.getTimeInstance(), DateFormat.getDateInstance(), DateFormat.getTimeInstance());
+        addValues(DateTimeFormatter.class, DateTimeFormatter.ISO_TIME, DateTimeFormatter.ISO_DATE, DateTimeFormatter.ISO_TIME);
+        addValues(Duration.class, Duration.ZERO, Duration.ofDays(1L), Duration.ZERO);
+        addValues(GregorianCalendar.class, new GregorianCalendar(2010, 7, 4), new GregorianCalendar(2010, 7, 5), new GregorianCalendar(2010, 7, 4));
+        addValues(Instant.class, Instant.MIN, Instant.MAX, Instant.MIN);
+        addValues(LocalDateTime.class, LocalDateTime.MIN, LocalDateTime.MAX, LocalDateTime.MIN);
+        addValues(LocalDate.class, LocalDate.MIN, LocalDate.MAX, LocalDate.MIN);
+        addValues(LocalTime.class, LocalTime.MIN, LocalTime.MAX, LocalTime.MIN);
+        addValues(MonthDay.class,
+            MonthDay.of(1, 1),
+            MonthDay.of(12, 31),
+            MonthDay.of(1, 1));
+        addValues(OffsetDateTime.class, OffsetDateTime.MIN, OffsetDateTime.MAX, OffsetDateTime.MIN);
+        addValues(OffsetTime.class, OffsetTime.MIN, OffsetTime.MAX, OffsetTime.MIN);
+        addValues(Period.class, Period.ZERO, Period.of(1, 1, 1), Period.ZERO);
+        addValues(SimpleDateFormat.class, new SimpleDateFormat("yMd"), new SimpleDateFormat("dMy"), new SimpleDateFormat("yMd"));
+        addValues(TimeZone.class, TimeZone.getTimeZone("GMT+1"), TimeZone.getTimeZone("GMT+2"), TimeZone.getTimeZone("GMT+1"));
+        addValues(Year.class, Year.of(2000), Year.of(2010), Year.of(2000));
+        addValues(YearMonth.class,
+            YearMonth.of(2000, 1),
+            YearMonth.of(2010, 12),
+            YearMonth.of(2000, 1));
         addValues(ZoneId.class, ZoneId.of("+1"), ZoneId.of("-10"), ZoneId.of("+1"));
         addValues(ZoneOffset.class, ZoneOffset.ofHours(1), ZoneOffset.ofHours(-1), ZoneOffset.ofHours(1));
         addValues(ZonedDateTime.class,
             ZonedDateTime.parse("2017-12-13T10:15:30+01:00"),
             ZonedDateTime.parse("2016-11-12T09:14:29-01:00"),
             ZonedDateTime.parse("2017-12-13T10:15:30+01:00"));
-
-        addFactory(CompletableFuture.class, simple(ignored -> new CompletableFuture<>(), CompletableFuture::new));
-        addFactory(Optional.class, simple(Optional::of, Optional::empty));
-        addFactory(Supplier.class, simple(a -> () -> a, () -> () -> null));
     }
 
     private void addUncommonClasses() {

--- a/src/test/java/nl/jqno/equalsverifier/integration/extended_contract/JavaApiClassesTest.java
+++ b/src/test/java/nl/jqno/equalsverifier/integration/extended_contract/JavaApiClassesTest.java
@@ -338,14 +338,26 @@ public class JavaApiClassesTest extends ExpectedExceptionTestBase {
         private final CompletableFuture<?> completableFuture;
         private final StampedLock stampedLock;
         private final Supplier<?> supplier;
+        private final Duration duration;
+        private final Instant instant;
+        private final MonthDay monthDay;
+        private final OffsetDateTime offsetDateTime;
+        private final OffsetTime offsetTime;
+        private final Period period;
+        private final Year year;
+        private final YearMonth yearMonth;
 
         // CHECKSTYLE: ignore ParameterNumber for 1 line.
         public Java8ApiClassesContainer(Optional<?> optional, LocalDate localDate, LocalTime localTime, LocalDateTime localDateTime,
                 ZoneId zoneId, ZoneOffset zoneOffset, ZonedDateTime zonedDateTime, DateTimeFormatter dateTimeFormatter,
-                CompletableFuture<?> completableFuture, StampedLock stampedLock, Supplier<?> supplier) {
+                CompletableFuture<?> completableFuture, StampedLock stampedLock, Supplier<?> supplier,
+                Duration duration, Instant instant, MonthDay monthDay, OffsetDateTime offsetDateTime,
+                OffsetTime offsetTime, Period period, Year year, YearMonth yearMonth) {
             this.optional = optional; this.localDate = localDate; this.localTime = localTime; this.localDateTime = localDateTime;
             this.zoneId = zoneId; this.zoneOffset = zoneOffset; this.zonedDateTime = zonedDateTime; this.dateTimeFormatter = dateTimeFormatter;
             this.completableFuture = completableFuture; this.stampedLock = stampedLock; this.supplier = supplier;
+            this.duration = duration; this.instant = instant; this.monthDay = monthDay; this.offsetDateTime = offsetDateTime;
+            this.offsetTime = offsetTime; this.period = period; this.year = year; this.yearMonth = yearMonth;
         }
 
         @Override public boolean equals(Object obj) { return defaultEquals(this, obj); }


### PR DESCRIPTION
# What problem does this pull request solve?
https://github.com/jqno/equalsverifier/issues/217

# Please provide any additional information below.
This adds prefabricated values for the remaining [java.time](https://docs.oracle.com/javase/8/docs/api/java/time/package-summary.html) classes, except [Clock](https://docs.oracle.com/javase/8/docs/api/java/time/Clock.html), to fix Java 9+ illegal access warnings. I wasn't really sure what to do with `Clock`, as it's abstract and all the subclasses in the JDK are package-private. It doesn't seem like it would be used in the same way as the rest of these.