### PR TITLE
bumpt checkstyle to 8.24; move checkstyle's LineLenght Check to Checker

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -59,7 +59,7 @@
         <java.release>8</java.release>
         <jacoco.version>0.8.4</jacoco.version>
 
-        <checkstyle.version>8.20</checkstyle.version> <!-- Property for Checkstyle's regression CI - see issue 216 -->
+        <checkstyle.version>8.24</checkstyle.version> <!-- Property for Checkstyle's regression CI - see issue 216 -->
         <checkstyle.maven.version>3.0.0</checkstyle.maven.version>
         <checkstyle.config>project/checkstyle-config.xml</checkstyle.config>
 
@@ -525,12 +525,12 @@
 
         <profile>
             <id>experimental-support-for-EA-version</id>
-            
+
             <properties>
                 <!-- Byte Buddy often supports new class file versions for current EA releases if its experimental flag is set to true -->
                 <surefire.argLine>--illegal-access=deny -Dnet.bytebuddy.experimental=true</surefire.argLine>
             </properties>
-            
+
             <build>
                 <plugins>
                     <!-- These plugins often lag behind a little when it comes to supporting new class file versions -->

--- a/project/checkstyle-config.xml
+++ b/project/checkstyle-config.xml
@@ -17,6 +17,15 @@
     <module name="NewlineAtEndOfFile">
         <property name="lineSeparator" value="lf"/>
     </module>
+    <module name="LineLength">
+        <property name="fileExtensions" value="java"/>
+        <property name="max" value="150"/>
+    </module>
+    <module name="SuppressWithPlainTextCommentFilter">
+        <property name="offCommentFormat" value="CHECKSTYLE OFF\: ([\w\|]+)"/>
+        <property name="onCommentFormat" value="CHECKSTYLE ON\: ([\w\|]+)"/>
+        <property name="checkFormat" value="$1"/>
+    </module>
 
     <module name="TreeWalker">
         <module name="SuppressWithNearbyCommentFilter">
@@ -86,9 +95,6 @@
         <module name="JavadocStyle"/>
         <module name="JavadocTagContinuationIndentation"/>
         <module name="JavaNCSS"/>
-        <module name="LineLength">
-            <property name="max" value="150"/>
-        </module>
         <module name="LocalFinalVariableName"/>
         <module name="LocalVariableName"/>
         <module name="MemberName"/>

--- a/src/test/java/nl/jqno/equalsverifier/integration/extra_features/VersionedEntityTest.java
+++ b/src/test/java/nl/jqno/equalsverifier/integration/extra_features/VersionedEntityTest.java
@@ -48,12 +48,13 @@ public class VersionedEntityTest extends ExpectedExceptionTestBase {
     }
 
     @Test
-    // CHECKSTYLE: ignore LineLength for 1 line.
+    // CHECKSTYLE OFF: LineLength.
     public void succeed_whenInstanceWithAZeroIdDoesNotEqualItselfAndInstanceWithANonzeroIdDoes_givenAVersionedEntityWithStateAndVersionedEntityWarningIsSuppressed() {
         EqualsVerifier.forClass(StringVersionedEntity.class)
                 .suppress(Warning.IDENTICAL_COPY_FOR_VERSIONED_ENTITY)
                 .verify();
     }
+    // CHECKSTYLE ON: LineLength.
 
     @Test
     public void fail_whenInstanceWithAZeroIdCanEqualItselfAndInstanceWithANonzeroIdAlso_givenAVersionedEntityWithState() {
@@ -63,20 +64,22 @@ public class VersionedEntityTest extends ExpectedExceptionTestBase {
     }
 
     @Test
-    // CHECKSTYLE: ignore LineLength for 1 line.
+    // CHECKSTYLE OFF: LineLength.
     public void succeed_whenInstanceWithAZeroIdCanEqualItselfAndInstanceWithANonzeroIdAlso_givenAVersionedEntityWithStateAndVersionedEntityWarningIsSuppressed() {
         EqualsVerifier.forClass(WeakStringVersionedEntity.class)
                 .suppress(Warning.IDENTICAL_COPY_FOR_VERSIONED_ENTITY)
                 .verify();
     }
+    // CHECKSTYLE ON: LineLength.
 
     @Test
-    // CHECKSTYLE: ignore LineLength for 1 line.
+    // CHECKSTYLE OFF: LineLength
     public void succeed_whenInstanceWithAZeroIdCanEqualItselfAndInstanceWithANonzeroIdAlso_givenAVersionedEntityWithStateAndAllFieldsWarningIsSuppressed() {
         EqualsVerifier.forClass(WeakStringVersionedEntity.class)
                 .suppress(Warning.ALL_FIELDS_SHOULD_BE_USED)
                 .verify();
     }
+    // CHECKSTYLE ON: LineLength.
 
     @Test
     public void fail_whenAnExceptionIsThrownInADifficultToReachPartOfTheSubclassOfAVersionedEntity() {


### PR DESCRIPTION
> What problem does this pull request solve?

upgrade to latest version of checkstyle to let keep using of this project in regression testing.

> Please provide any additional information below.

migration of checkstyle config is provided.
unfortunate side effect of previous suppresion  stop to work due to our redesign of Filters.
new SuppressWithPlainTextCommentFilter is provided to some sort of substitution of previous functionality.
