### PR TITLE
upgrade maven-checkstyle-plugin to 3.1.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -60,7 +60,7 @@
         <jacoco.version>0.8.4</jacoco.version>
 
         <checkstyle.version>8.24</checkstyle.version> <!-- Property for Checkstyle's regression CI - see issue 216 -->
-        <checkstyle.maven.version>3.0.0</checkstyle.maven.version>
+        <checkstyle.maven.version>3.1.0</checkstyle.maven.version>
         <checkstyle.config>project/checkstyle-config.xml</checkstyle.config>
 
         <spotbugs.version>4.0.0-beta3</spotbugs.version>

--- a/project/checkstyle-config.xml
+++ b/project/checkstyle-config.xml
@@ -89,7 +89,6 @@
         <module name="InterfaceIsType"/>
         <module name="InterfaceTypeParameterName"/>
         <module name="JavadocMethod">
-            <property name="allowMissingJavadoc" value="true"/>
             <property name="scope" value="public"/>
         </module>
         <module name="JavadocStyle"/>


### PR DESCRIPTION
Identified at checkstyle/checkstyle#7088

Checkstyle is looking to remove some deprecated methods and our CI noticed that you are not on the latest maven-checkstyle-plugin which is still using some deprecated methods.