### PR TITLE
use fully qualified class name in error message

### DIFF
--- a/src/main/java/nl/jqno/equalsverifier/EqualsVerifierApi.java
+++ b/src/main/java/nl/jqno/equalsverifier/EqualsVerifierApi.java
@@ -317,7 +317,7 @@ public class EqualsVerifierApi<T> {
         return Formatter.of(
                         "EqualsVerifier found a problem in class %%.\n-> %%\n\n"
                                 + "For more information, go to: http://www.jqno.nl/equalsverifier/errormessages",
-                        type.getSimpleName(), description)
+                        type.getName(), description)
                 .format();
     }
 

--- a/src/test/java/nl/jqno/equalsverifier/integration/operational/ReportTest.java
+++ b/src/test/java/nl/jqno/equalsverifier/integration/operational/ReportTest.java
@@ -26,7 +26,9 @@ public class ReportTest {
 
         assertFalse(report.isSuccessful());
         assertThat(
-                report.getMessage(), startsWith("EqualsVerifier found a problem in class Point"));
+                report.getMessage(),
+                startsWith(
+                        "EqualsVerifier found a problem in class nl.jqno.equalsverifier.testhelpers.types.Point"));
         assertEquals(AssertionException.class, report.getCause().getClass());
         assertNull(report.getCause().getMessage());
     }


### PR DESCRIPTION
# What problem does this pull request solve?

currently, the error message is ambiguous. It uses Class.getSimpleName

# Please provide any additional information below.

Class.getName provides the fully qualified class name.
