### PR TITLE
Add exclusion method using a predicate

### DIFF
--- a/src/main/java/nl/jqno/equalsverifier/api/MultipleTypeEqualsVerifierApi.java
+++ b/src/main/java/nl/jqno/equalsverifier/api/MultipleTypeEqualsVerifierApi.java
@@ -2,6 +2,7 @@ package nl.jqno.equalsverifier.api;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.function.Predicate;
 import java.util.stream.Collectors;
 import nl.jqno.equalsverifier.ConfiguredEqualsVerifier;
 import nl.jqno.equalsverifier.EqualsVerifier;
@@ -72,9 +73,27 @@ public class MultipleTypeEqualsVerifierApi implements EqualsVerifierApi<Void> {
      */
     public MultipleTypeEqualsVerifierApi except(Class<?> type, Class<?>... more) {
         List<Class<?>> typesToRemove = ListBuilders.buildListOfAtLeastOne(type, more);
+        removeTypes(typesToRemove);
+        return this;
+    }
+
+    /**
+     * Removes all types matching the given Predicate.
+     *
+     * @param exclusionPredicate A Predicate matching classes to remove from the list of types to
+     *     verify.
+     * @return {@code this}, for easy method chaining.
+     */
+    public MultipleTypeEqualsVerifierApi except(Predicate<Class<?>> exclusionPredicate) {
+        List<Class<?>> typesToRemove =
+                types.stream().filter(exclusionPredicate).collect(Collectors.toList());
+        removeTypes(typesToRemove);
+        return this;
+    }
+
+    private void removeTypes(List<Class<?>> typesToRemove) {
         Validations.validateTypesAreKnown(typesToRemove, types);
         types.removeAll(typesToRemove);
-        return this;
     }
 
     /**

--- a/src/test/java/nl/jqno/equalsverifier/integration/operational/ConfiguredEqualsVerifierMultipleTest.java
+++ b/src/test/java/nl/jqno/equalsverifier/integration/operational/ConfiguredEqualsVerifierMultipleTest.java
@@ -1,9 +1,5 @@
 package nl.jqno.equalsverifier.integration.operational;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
-
-import java.util.List;
 import nl.jqno.equalsverifier.ConfiguredEqualsVerifier;
 import nl.jqno.equalsverifier.EqualsVerifier;
 import nl.jqno.equalsverifier.EqualsVerifierReport;
@@ -24,13 +20,21 @@ import nl.jqno.equalsverifier.testhelpers.types.TypeHelper.SingleGenericContaine
 import nl.jqno.equalsverifier.testhelpers.types.TypeHelper.SingleGenericContainerContainer;
 import org.junit.Test;
 
+import java.util.List;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
 public class ConfiguredEqualsVerifierMultipleTest extends ExpectedExceptionTestBase {
+
+    private final String PACKAGE_WITH_ONLY_CORRECT_FILES =
+            "nl.jqno.equalsverifier.testhelpers.packages.correct";
+    private final String PACKAGE_WITH_TWO_INCORRECT_FILES =
+            "nl.jqno.equalsverifier.testhelpers.packages.twoincorrect";
 
     @Test
     public void succeed_whenCallingForPackage_givenAllClassesInPackageAreCorrect() {
-        EqualsVerifier.configure()
-                .forPackage("nl.jqno.equalsverifier.testhelpers.packages.correct")
-                .verify();
+        EqualsVerifier.configure().forPackage(PACKAGE_WITH_ONLY_CORRECT_FILES).verify();
     }
 
     @Test
@@ -42,8 +46,7 @@ public class ConfiguredEqualsVerifierMultipleTest extends ExpectedExceptionTestB
                 "Subclass: equals is not final.",
                 "Reflexivity: object does not equal itself:");
 
-        EqualsVerifier.forPackage("nl.jqno.equalsverifier.testhelpers.packages.twoincorrect")
-                .verify();
+        EqualsVerifier.forPackage(PACKAGE_WITH_TWO_INCORRECT_FILES).verify();
     }
 
     @Test
@@ -59,7 +62,7 @@ public class ConfiguredEqualsVerifierMultipleTest extends ExpectedExceptionTestB
     @Test
     public void
             succeed_whenCallingForPackageOnAPackageContainingFailingClasses_givenFailingClassesAreExcepted() {
-        EqualsVerifier.forPackage("nl.jqno.equalsverifier.testhelpers.packages.twoincorrect")
+        EqualsVerifier.forPackage(PACKAGE_WITH_TWO_INCORRECT_FILES)
                 .except(IncorrectM.class, IncorrectN.class)
                 .verify();
     }
@@ -68,8 +71,29 @@ public class ConfiguredEqualsVerifierMultipleTest extends ExpectedExceptionTestB
     public void fail_whenExceptingAClassThatDoesntExistInThePackage() {
         expectException(IllegalStateException.class, "Unknown class(es) found", "IncorrectM");
 
-        EqualsVerifier.forPackage("nl.jqno.equalsverifier.testhelpers.packages.correct")
-                .except(IncorrectM.class);
+        EqualsVerifier.forPackage(PACKAGE_WITH_ONLY_CORRECT_FILES).except(IncorrectM.class);
+    }
+
+    @Test
+    public void
+            succeed_whenCallingForPackageOnAPackageContainingFailingClasses_givenFailingClassesAreExceptedByPredicate() {
+        EqualsVerifier.forPackage(PACKAGE_WITH_TWO_INCORRECT_FILES)
+                .except(c -> c.getSimpleName().contains("Incorrect"))
+                .verify();
+    }
+
+    @Test
+    public void
+            fail_whenCallingForPackageOnAPackageContainingFailingClasses_givenFailingClassesAreNotExceptedByPredicate() {
+        expectFailure("EqualsVerifier found a problem in 2 classes");
+
+        EqualsVerifier.forPackage(PACKAGE_WITH_TWO_INCORRECT_FILES).except(c -> false).verify();
+    }
+
+    @Test
+    public void
+            succeed_whenCallingForPackageOnAPackageContainingFailingClasses_givenAllClassesAreExceptedByPredicate() {
+        EqualsVerifier.forPackage(PACKAGE_WITH_TWO_INCORRECT_FILES).except(c -> true).verify();
     }
 
     @Test

--- a/src/test/java/nl/jqno/equalsverifier/integration/operational/ConfiguredEqualsVerifierMultipleTest.java
+++ b/src/test/java/nl/jqno/equalsverifier/integration/operational/ConfiguredEqualsVerifierMultipleTest.java
@@ -1,13 +1,15 @@
 package nl.jqno.equalsverifier.integration.operational;
 
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.util.List;
 import nl.jqno.equalsverifier.ConfiguredEqualsVerifier;
 import nl.jqno.equalsverifier.EqualsVerifier;
 import nl.jqno.equalsverifier.EqualsVerifierReport;
 import nl.jqno.equalsverifier.Warning;
 import nl.jqno.equalsverifier.testhelpers.ExpectedExceptionTestBase;
 import nl.jqno.equalsverifier.testhelpers.packages.correct.A;
-import nl.jqno.equalsverifier.testhelpers.packages.twoincorrect.IncorrectM;
-import nl.jqno.equalsverifier.testhelpers.packages.twoincorrect.IncorrectN;
 import nl.jqno.equalsverifier.testhelpers.types.FinalMethodsPoint;
 import nl.jqno.equalsverifier.testhelpers.types.GetClassPoint;
 import nl.jqno.equalsverifier.testhelpers.types.MutablePoint;
@@ -20,81 +22,7 @@ import nl.jqno.equalsverifier.testhelpers.types.TypeHelper.SingleGenericContaine
 import nl.jqno.equalsverifier.testhelpers.types.TypeHelper.SingleGenericContainerContainer;
 import org.junit.Test;
 
-import java.util.List;
-
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
-
 public class ConfiguredEqualsVerifierMultipleTest extends ExpectedExceptionTestBase {
-
-    private final String PACKAGE_WITH_ONLY_CORRECT_FILES =
-            "nl.jqno.equalsverifier.testhelpers.packages.correct";
-    private final String PACKAGE_WITH_TWO_INCORRECT_FILES =
-            "nl.jqno.equalsverifier.testhelpers.packages.twoincorrect";
-
-    @Test
-    public void succeed_whenCallingForPackage_givenAllClassesInPackageAreCorrect() {
-        EqualsVerifier.configure().forPackage(PACKAGE_WITH_ONLY_CORRECT_FILES).verify();
-    }
-
-    @Test
-    public void fail_whenCallingForPackage_givenTwoClassesInPackageAreIncorrect() {
-        expectFailure(
-                "EqualsVerifier found a problem in 2 classes.",
-                "IncorrectM",
-                "IncorrectN",
-                "Subclass: equals is not final.",
-                "Reflexivity: object does not equal itself:");
-
-        EqualsVerifier.forPackage(PACKAGE_WITH_TWO_INCORRECT_FILES).verify();
-    }
-
-    @Test
-    public void fail_whenCallingForPackage_whenPackageHasNoClasses() {
-        expectException(
-                IllegalStateException.class,
-                "nl.jqno.equalsverifier.doesnotexist",
-                "doesn't contain any (non-Test) types");
-
-        EqualsVerifier.forPackage("nl.jqno.equalsverifier.doesnotexist");
-    }
-
-    @Test
-    public void
-            succeed_whenCallingForPackageOnAPackageContainingFailingClasses_givenFailingClassesAreExcepted() {
-        EqualsVerifier.forPackage(PACKAGE_WITH_TWO_INCORRECT_FILES)
-                .except(IncorrectM.class, IncorrectN.class)
-                .verify();
-    }
-
-    @Test
-    public void fail_whenExceptingAClassThatDoesntExistInThePackage() {
-        expectException(IllegalStateException.class, "Unknown class(es) found", "IncorrectM");
-
-        EqualsVerifier.forPackage(PACKAGE_WITH_ONLY_CORRECT_FILES).except(IncorrectM.class);
-    }
-
-    @Test
-    public void
-            succeed_whenCallingForPackageOnAPackageContainingFailingClasses_givenFailingClassesAreExceptedByPredicate() {
-        EqualsVerifier.forPackage(PACKAGE_WITH_TWO_INCORRECT_FILES)
-                .except(c -> c.getSimpleName().contains("Incorrect"))
-                .verify();
-    }
-
-    @Test
-    public void
-            fail_whenCallingForPackageOnAPackageContainingFailingClasses_givenFailingClassesAreNotExceptedByPredicate() {
-        expectFailure("EqualsVerifier found a problem in 2 classes");
-
-        EqualsVerifier.forPackage(PACKAGE_WITH_TWO_INCORRECT_FILES).except(c -> false).verify();
-    }
-
-    @Test
-    public void
-            succeed_whenCallingForPackageOnAPackageContainingFailingClasses_givenAllClassesAreExceptedByPredicate() {
-        EqualsVerifier.forPackage(PACKAGE_WITH_TWO_INCORRECT_FILES).except(c -> true).verify();
-    }
 
     @Test
     public void

--- a/src/test/java/nl/jqno/equalsverifier/integration/operational/MultipleTypeEqualsVerifierTest.java
+++ b/src/test/java/nl/jqno/equalsverifier/integration/operational/MultipleTypeEqualsVerifierTest.java
@@ -10,8 +10,11 @@ import java.util.List;
 import nl.jqno.equalsverifier.EqualsVerifier;
 import nl.jqno.equalsverifier.EqualsVerifierReport;
 import nl.jqno.equalsverifier.testhelpers.ExpectedExceptionTestBase;
-import nl.jqno.equalsverifier.testhelpers.packages.correct.*;
-import nl.jqno.equalsverifier.testhelpers.packages.twoincorrect.*;
+import nl.jqno.equalsverifier.testhelpers.packages.correct.A;
+import nl.jqno.equalsverifier.testhelpers.packages.correct.B;
+import nl.jqno.equalsverifier.testhelpers.packages.correct.C;
+import nl.jqno.equalsverifier.testhelpers.packages.twoincorrect.IncorrectM;
+import nl.jqno.equalsverifier.testhelpers.packages.twoincorrect.IncorrectN;
 import org.junit.Test;
 
 public class MultipleTypeEqualsVerifierTest extends ExpectedExceptionTestBase {
@@ -30,16 +33,6 @@ public class MultipleTypeEqualsVerifierTest extends ExpectedExceptionTestBase {
     @Test
     public void succeed_whenVerifyingACorrectPackage() {
         EqualsVerifier.forPackage(CORRECT_PACKAGE).verify();
-    }
-
-    @Test
-    public void fail_whenCallingForPackage_whenPackageHasNoClasses() {
-        expectException(
-                IllegalStateException.class,
-                "nl.jqno.equalsverifier.doesnotexist",
-                "doesn't contain any (non-Test) types");
-
-        EqualsVerifier.forPackage("nl.jqno.equalsverifier.doesnotexist");
     }
 
     @Test
@@ -74,6 +67,70 @@ public class MultipleTypeEqualsVerifierTest extends ExpectedExceptionTestBase {
                 "Reflexivity: object does not equal itself:");
 
         EqualsVerifier.forPackage(INCORRECT_PACKAGE).verify();
+    }
+
+    @Test
+    public void succeed_whenCallingForPackage_givenAllClassesInPackageAreCorrect() {
+        EqualsVerifier.configure().forPackage(CORRECT_PACKAGE).verify();
+    }
+
+    @Test
+    public void fail_whenCallingForPackage_givenTwoClassesInPackageAreIncorrect() {
+        expectFailure(
+                "EqualsVerifier found a problem in 2 classes.",
+                "IncorrectM",
+                "IncorrectN",
+                "Subclass: equals is not final.",
+                "Reflexivity: object does not equal itself:");
+
+        EqualsVerifier.forPackage(INCORRECT_PACKAGE).verify();
+    }
+
+    @Test
+    public void fail_whenCallingForPackage_whenPackageHasNoClasses() {
+        expectException(
+                IllegalStateException.class,
+                "nl.jqno.equalsverifier.doesnotexist",
+                "doesn't contain any (non-Test) types");
+
+        EqualsVerifier.forPackage("nl.jqno.equalsverifier.doesnotexist");
+    }
+
+    @Test
+    public void
+            succeed_whenCallingForPackageOnAPackageContainingFailingClasses_givenFailingClassesAreExcepted() {
+        EqualsVerifier.forPackage(INCORRECT_PACKAGE)
+                .except(IncorrectM.class, IncorrectN.class)
+                .verify();
+    }
+
+    @Test
+    public void fail_whenExceptingAClassThatDoesntExistInThePackage() {
+        expectException(IllegalStateException.class, "Unknown class(es) found", "IncorrectM");
+
+        EqualsVerifier.forPackage(CORRECT_PACKAGE).except(IncorrectM.class);
+    }
+
+    @Test
+    public void
+            succeed_whenCallingForPackageOnAPackageContainingFailingClasses_givenFailingClassesAreExceptedByPredicate() {
+        EqualsVerifier.forPackage(INCORRECT_PACKAGE)
+                .except(c -> c.getSimpleName().contains("Incorrect"))
+                .verify();
+    }
+
+    @Test
+    public void
+            fail_whenCallingForPackageOnAPackageContainingFailingClasses_givenFailingClassesAreNotExceptedByPredicate() {
+        expectFailure("EqualsVerifier found a problem in 2 classes");
+
+        EqualsVerifier.forPackage(INCORRECT_PACKAGE).except(c -> false).verify();
+    }
+
+    @Test
+    public void
+            succeed_whenCallingForPackageOnAPackageContainingFailingClasses_givenAllClassesAreExceptedByPredicate() {
+        EqualsVerifier.forPackage(INCORRECT_PACKAGE).except(c -> true).verify();
     }
 
     @Test


### PR DESCRIPTION
# What problem does this pull request solve?

For teams using the new "forPackage" folder, it could become a bit cumbersome to add all the specific classes to the "except(...)" method. This pull request adds a "except(Predicate)" to give a bit more flexibility for excluding classes.

# Please provide any additional information below.

I see a decent amount of teams where they divide their code in packages based on functionality (ex, invoice, customers, stock, ..) instead of technical layers (ex. api, domain, repositories). While the newly added **forPackage** is great when using technical layers, it is less convenient for the former. 

We use EqualsVerifier exclusively for domain objects. If those objects are in separate functional packages with a lot of other classes (to use package-private visibility), then the list of exclusions is quite a bit longer than we'd like to maintain.

