### PR TITLE
Exclude net.bytebuddy.experimental from shading scope

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -274,6 +274,9 @@
                                 <relocation>
                                     <pattern>net.bytebuddy</pattern>
                                     <shadedPattern>nl.jqno.equalsverifier.internal.lib.bytebuddy</shadedPattern>
+                                    <excludes>
+                                        <exclude>net/bytebuddy/experimental</exclude>
+                                    </excludes>
                                 </relocation>
                                 <relocation>
                                     <pattern>org.objenesis</pattern>


### PR DESCRIPTION
This ensures that ByteBuddy experimental features can be enabled setting the 'net.bytebuddy.experimental' property also when EqualsVerifier is used as a dependency of other applications.

Fixes #339.