### PR TITLE
Please reuse Objenesis instance to reduce class loading/unloading

### DIFF
--- a/src/main/java/nl/jqno/equalsverifier/internal/reflection/Instantiator.java
+++ b/src/main/java/nl/jqno/equalsverifier/internal/reflection/Instantiator.java
@@ -9,8 +9,7 @@ import java.util.List;
 import net.bytebuddy.ByteBuddy;
 import net.bytebuddy.dynamic.loading.ClassLoadingStrategy;
 import net.bytebuddy.dynamic.scaffold.TypeValidation;
-import org.objenesis.Objenesis;
-import org.objenesis.ObjenesisStd;
+import org.objenesis.ObjenesisHelper;
 
 /**
  * Instantiates objects of a given class.
@@ -30,12 +29,10 @@ public final class Instantiator<T> {
     private static final String FALLBACK_PACKAGE_NAME = getPackageName(Instantiator.class);
 
     private final Class<T> type;
-    private Objenesis objenesis;
 
     /** Private constructor. Call {@link #of(Class)} to instantiate. */
     private Instantiator(Class<T> type) {
         this.type = type;
-        this.objenesis = new ObjenesisStd();
     }
 
     /**
@@ -61,7 +58,7 @@ public final class Instantiator<T> {
      * @return An object of type T.
      */
     public T instantiate() {
-        return objenesis.newInstance(type);
+        return ObjenesisHelper.newInstance(type);
     }
 
     /**
@@ -71,7 +68,7 @@ public final class Instantiator<T> {
      */
     public T instantiateAnonymousSubclass() {
         Class<T> proxyClass = giveDynamicSubclass(type);
-        return objenesis.newInstance(proxyClass);
+        return ObjenesisHelper.newInstance(proxyClass);
     }
 
     @SuppressWarnings("unchecked")


### PR DESCRIPTION
`Instantiator` creates a new instance of Objenesis for every instance it creates. Objenesis is made to be reused and caches the loaded classes inside, so the jvm does not need to recreate them every time.

```java
public class Main {
    public static void main(String[] args) {
        IntStream.range(0, 5000000).parallel().forEach(value -> {
            System.out.println("tick " + value);
            EqualsVerifier.forClass(Foo.class).withNonnullFields("testId", "result").verify();
        });
    }
}

public final class Foo {
    private final String testId;
    private final Status result;

    public Foo(String testId, Status result) {
        this.testId = requireNonNull(testId);
        this.result = requireNonNull(result);
    }
 ... removed
}
```

The above example will continuously create and load new classes in the jvm, which then have to be unloaded.
After some time this can even take the jvm down because it fully freezes/locks for 30+ seconds while unloading classes. 
`[43,321s][debug][gc,phases      ] GC(1) ClassLoaderData 34830,025ms`
If you monitor the classes for example in visualvm, you will also see it creating 20-40k classes continuously and struggle to gc them.

The locking/freezing can be seen as a jvm  bug however with this change to reuse objenesis no more then 3k classes total are ever created in this example.

This was found while investigating why https://github.com/junit-pioneer/junit-pioneer froze while running tests on repeat to detect concurrency issues.

