### PR TITLE
non-nullity depends on null annotations

### DIFF
--- a/docs/_errormessages/non-nullity-equals-hashcode-tostring-throws-nullpointerexception.md
+++ b/docs/_errormessages/non-nullity-equals-hashcode-tostring-throws-nullpointerexception.md
@@ -1,11 +1,11 @@
 ---
-title: "Non-nullity: equals/hashCode/toString throws NullPointerExcpetion"
+title: "Non-nullity: equals/hashCode/toString throws NullPointerException"
 ---
 This error occurs when the class under test can throw a `NullPointerException` when one of its fields is null and `equals`/`hashCode`/`toString` is called. For example, `equals` could contain this line:
 {% highlight java %}
 return foo.equals(other.foo);
 {% endhighlight %}
-It will throw a `NullPointerException` if `foo` is null. This can be avoided in three ways:
+It will throw a `NullPointerException` if `foo` is null. This can be avoided in multiple ways:
 
 * In Java 7 and up, you can use `Objects.equals`, which is null-safe:
 {% highlight java %}
@@ -17,7 +17,9 @@ return Objects.equals(foo, other.foo);
 return foo == null ? other.foo == null : foo.equals(other.foo);
 {% endhighlight %}
 
-* If you're certain the field can never be null (for instance, because the class's constructor explicitly checks for it), you can add `.withNonnullFields("foo")` to your call to EqualsVerifier
+* If you're certain the field can never be null (for instance, because the class's constructor explicitly checks for it), you can add `.withNonnullFields("foo")` to your call to EqualsVerifier.
+
+* If you use @NonNull/@NotNull/@Nullable or similar annotations in your code, then make sure the annotations are available on the classpath when the test is executed.
 
 * If this problem occurs for many fields in the same class, you can suppress `Warning.NULL_FIELDS` in your call to EqualsVerifier.
 


### PR DESCRIPTION
Describe the dependency of this error message to available null annotations. I had accidentally removed org.eclipse.jdt.annotations from the classpath and got this error. Re-adding the null annotations lib removed the error message.