### PR TITLE
config: change scope to access modifiers for JavadocMethod

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -63,7 +63,7 @@
         <maven-compiler-plugin.version>3.8.1</maven-compiler-plugin.version>
         <build-helper-maven-plugin.version>3.2.0</build-helper-maven-plugin.version>
 
-        <checkstyle.version>8.41.1</checkstyle.version> <!-- Property for Checkstyle's regression CI - see issue 216 -->
+        <checkstyle.version>8.42</checkstyle.version> <!-- Property for Checkstyle's regression CI - see issue 216 -->
         <checkstyle.maven.version>3.1.2</checkstyle.maven.version>
         <checkstyle.config>project/checkstyle-config.xml</checkstyle.config>
 

--- a/project/checkstyle-config.xml
+++ b/project/checkstyle-config.xml
@@ -65,7 +65,7 @@
         <module name="InterfaceIsType"/>
         <module name="InterfaceTypeParameterName"/>
         <module name="JavadocMethod">
-            <property name="scope" value="public"/>
+            <property name="accessModifiers" value="public"/>
         </module>
         <module name="JavadocStyle"/>
         <module name="JavadocTagContinuationIndentation"/>

--- a/src/main/java/nl/jqno/equalsverifier/internal/prefabvalues/Cache.java
+++ b/src/main/java/nl/jqno/equalsverifier/internal/prefabvalues/Cache.java
@@ -16,6 +16,7 @@ class Cache {
      * @param red A "red" value for the given type.
      * @param blue A "blue" value for the given type.
      * @param redCopy A shallow copy of the given red value.
+     * @param <T> The type of given tag.
      */
     public <T> void put(TypeTag tag, T red, T blue, T redCopy) {
         cache.put(tag, new Tuple<>(red, blue, redCopy));
@@ -28,6 +29,8 @@ class Cache {
      * first.
      *
      * @param tag A description of the type. Takes generics into account.
+     * @param <T> the type of the Tuple.
+     * @return Tuple of type T.
      */
     @SuppressWarnings("unchecked")
     public <T> Tuple<T> getTuple(TypeTag tag) {
@@ -38,6 +41,7 @@ class Cache {
      * Returns whether prefabricated values are available for the given type.
      *
      * @param tag A description of the type. Takes generics into account.
+     * @return true if prefabricated values are available.
      */
     public boolean contains(TypeTag tag) {
         return cache.containsKey(tag);


### PR DESCRIPTION
From failure at https://app.wercker.com/checkstyle/checkstyle/runs/build/6054d9b9237ec90008473aa6?step=6054dfea476e900008b0f46c in reference to https://github.com/checkstyle/checkstyle/issues/7417

Checkstyle has changed the `scope` property to `accessModifiers` in `JavadocMethodCheck`. This PR will update equalsverifier's Checkstyle config to accommodate this (breaking) change, which will be included in the next Checkstyle release.

Successful Checkstyle execution with new property on this project: https://gist.github.com/nmancus1/044ce991f2d56ff12bd2eaae50f5c448