### PR TITLE
Support for verifying a package and all sub-packages

### DIFF
--- a/src/main/java/nl/jqno/equalsverifier/ConfiguredEqualsVerifier.java
+++ b/src/main/java/nl/jqno/equalsverifier/ConfiguredEqualsVerifier.java
@@ -146,7 +146,21 @@ public final class ConfiguredEqualsVerifier implements EqualsVerifierApi<Void> {
      * @return A fluent API for EqualsVerifier.
      */
     public MultipleTypeEqualsVerifierApi forPackage(String packageName) {
-        List<Class<?>> classes = PackageScanner.getClassesIn(packageName);
+        return forPackage(packageName, false);
+    }
+
+    /**
+     * Factory method. For general use.
+     *
+     * <p>Note that this operation may be slow. If the test is too slow, use {@link
+     * #forClasses(Class, Class, Class...)} instead.
+     *
+     * @param packageName A package for which each class's {@code equals} should be tested.
+     * @param scanRecursively true to scan all sub-packages
+     * @return A fluent API for EqualsVerifier.
+     */
+    public MultipleTypeEqualsVerifierApi forPackage(String packageName, boolean scanRecursively) {
+        List<Class<?>> classes = PackageScanner.getClassesIn(packageName, scanRecursively);
         Validations.validatePackageContainsClasses(packageName, classes);
         return new MultipleTypeEqualsVerifierApi(classes, new ConfiguredEqualsVerifier());
     }

--- a/src/main/java/nl/jqno/equalsverifier/EqualsVerifier.java
+++ b/src/main/java/nl/jqno/equalsverifier/EqualsVerifier.java
@@ -126,7 +126,10 @@ public final class EqualsVerifier {
      * @param scanRecursively true to scan all sub-packages
      * @return A fluent API for EqualsVerifier.
      */
-    public static MultipleTypeEqualsVerifierApi forPackage(String packageName, boolean scanRecursively) {
+    public static MultipleTypeEqualsVerifierApi forPackage(
+        String packageName,
+        boolean scanRecursively
+    ) {
         List<Class<?>> classes = PackageScanner.getClassesIn(packageName, scanRecursively);
         Validations.validatePackageContainsClasses(packageName, classes);
         return new MultipleTypeEqualsVerifierApi(classes, new ConfiguredEqualsVerifier());

--- a/src/main/java/nl/jqno/equalsverifier/EqualsVerifier.java
+++ b/src/main/java/nl/jqno/equalsverifier/EqualsVerifier.java
@@ -113,7 +113,21 @@ public final class EqualsVerifier {
      * @return A fluent API for EqualsVerifier.
      */
     public static MultipleTypeEqualsVerifierApi forPackage(String packageName) {
-        List<Class<?>> classes = PackageScanner.getClassesIn(packageName);
+        return forPackage(packageName, false);
+    }
+
+    /**
+     * Factory method. For general use.
+     *
+     * <p>Note that this operation may be slow. If the test is too slow, use {@link
+     * #forClasses(Class, Class, Class...)} instead.
+     *
+     * @param packageName A package for which each class's {@code equals} should be tested.
+     * @param scanRecursively true to scan all sub-packages
+     * @return A fluent API for EqualsVerifier.
+     */
+    public static MultipleTypeEqualsVerifierApi forPackage(String packageName, boolean scanRecursively) {
+        List<Class<?>> classes = PackageScanner.getClassesIn(packageName, scanRecursively);
         Validations.validatePackageContainsClasses(packageName, classes);
         return new MultipleTypeEqualsVerifierApi(classes, new ConfiguredEqualsVerifier());
     }

--- a/src/main/java/nl/jqno/equalsverifier/internal/reflection/PackageScanner.java
+++ b/src/main/java/nl/jqno/equalsverifier/internal/reflection/PackageScanner.java
@@ -42,22 +42,29 @@ public final class PackageScanner {
         );
     }
 
-    private static List<Class<?>> getClassesInDir(String packageName, File dir, boolean scanRecursively) {
+    private static List<Class<?>> getClassesInDir(
+        String packageName,
+        File dir,
+        boolean scanRecursively
+    ) {
         if (!dir.exists()) {
             return Collections.emptyList();
         }
         return Arrays
             .stream(dir.listFiles())
             .filter(f -> (scanRecursively && f.isDirectory()) || f.getName().endsWith(".class"))
-            .flatMap(f -> {
-                List<Class<?>> classes;
-                if(f.isDirectory()) {
-                    classes = getClassesInDir(packageName + "." + f.getName(), f, scanRecursively);
-                } else {
-                    classes = Collections.singletonList(fileToClass(packageName, f));
+            .flatMap(
+                f -> {
+                    List<Class<?>> classes;
+                    if (f.isDirectory()) {
+                        classes =
+                            getClassesInDir(packageName + "." + f.getName(), f, scanRecursively);
+                    } else {
+                        classes = Collections.singletonList(fileToClass(packageName, f));
+                    }
+                    return classes.stream();
                 }
-                return classes.stream();
-            })
+            )
             .filter(c -> !c.getName().endsWith("Test"))
             .collect(Collectors.toList());
     }

--- a/src/test/java/nl/jqno/equalsverifier/integration/operational/MultipleTypeEqualsVerifierTest.java
+++ b/src/test/java/nl/jqno/equalsverifier/integration/operational/MultipleTypeEqualsVerifierTest.java
@@ -100,17 +100,17 @@ public class MultipleTypeEqualsVerifierTest {
     @Test
     public void fail_whenVerifyingAPackageRecursivelyWithFourIncorrectClasses() {
         ExpectedException
-                .when(() -> EqualsVerifier.forPackage(INCORRECT_PACKAGE, true).verify())
-                .assertFailure()
-                .assertMessageContains(
-                        "EqualsVerifier found a problem in 4 classes.",
-                        "* " + INCORRECT_M,
-                        "* " + INCORRECT_N,
-                        "* " + INCORRECT_O,
-                        "* " + INCORRECT_P,
-                        "Subclass: equals is not final.",
-                        "Reflexivity: object does not equal itself:"
-                );
+            .when(() -> EqualsVerifier.forPackage(INCORRECT_PACKAGE, true).verify())
+            .assertFailure()
+            .assertMessageContains(
+                "EqualsVerifier found a problem in 4 classes.",
+                "* " + INCORRECT_M,
+                "* " + INCORRECT_N,
+                "* " + INCORRECT_O,
+                "* " + INCORRECT_P,
+                "Subclass: equals is not final.",
+                "Reflexivity: object does not equal itself:"
+            );
     }
 
     @Test
@@ -130,17 +130,17 @@ public class MultipleTypeEqualsVerifierTest {
     @Test
     public void fail_whenCallingForPackageRecursively_givenFourClassesInPackageAreIncorrect() {
         ExpectedException
-                .when(() -> EqualsVerifier.forPackage(INCORRECT_PACKAGE, true).verify())
-                .assertFailure()
-                .assertMessageContains(
-                        "EqualsVerifier found a problem in 4 classes.",
-                        "IncorrectM",
-                        "IncorrectN",
-                        "IncorrectO",
-                        "IncorrectP",
-                        "Subclass: equals is not final.",
-                        "Reflexivity: object does not equal itself:"
-                );
+            .when(() -> EqualsVerifier.forPackage(INCORRECT_PACKAGE, true).verify())
+            .assertFailure()
+            .assertMessageContains(
+                "EqualsVerifier found a problem in 4 classes.",
+                "IncorrectM",
+                "IncorrectN",
+                "IncorrectO",
+                "IncorrectP",
+                "Subclass: equals is not final.",
+                "Reflexivity: object does not equal itself:"
+            );
     }
 
     @Test
@@ -157,12 +157,12 @@ public class MultipleTypeEqualsVerifierTest {
     @Test
     public void fail_whenCallingForPackageRecursively_whenPackageHasNoClasses() {
         ExpectedException
-                .when(() -> EqualsVerifier.forPackage("nl.jqno.equalsverifier.doesnotexist", true))
-                .assertThrows(IllegalStateException.class)
-                .assertMessageContains(
-                        "nl.jqno.equalsverifier.doesnotexist",
-                        "doesn't contain any (non-Test) types"
-                );
+            .when(() -> EqualsVerifier.forPackage("nl.jqno.equalsverifier.doesnotexist", true))
+            .assertThrows(IllegalStateException.class)
+            .assertMessageContains(
+                "nl.jqno.equalsverifier.doesnotexist",
+                "doesn't contain any (non-Test) types"
+            );
     }
 
     @Test
@@ -176,9 +176,9 @@ public class MultipleTypeEqualsVerifierTest {
     @Test
     public void succeed_whenCallingForPackageRecursivelyOnAPackageContainingFailingClasses_givenFailingClassesAreExcepted() {
         EqualsVerifier
-                .forPackage(INCORRECT_PACKAGE, true)
-                .except(IncorrectM.class, IncorrectN.class, IncorrectO.class, IncorrectP.class)
-                .verify();
+            .forPackage(INCORRECT_PACKAGE, true)
+            .except(IncorrectM.class, IncorrectN.class, IncorrectO.class, IncorrectP.class)
+            .verify();
     }
 
     @Test
@@ -192,9 +192,9 @@ public class MultipleTypeEqualsVerifierTest {
     @Test
     public void fail_whenExceptingAClassThatDoesntExistInThePackageAndSubPackages() {
         ExpectedException
-                .when(() -> EqualsVerifier.forPackage(CORRECT_PACKAGE, true).except(IncorrectM.class))
-                .assertThrows(IllegalStateException.class)
-                .assertMessageContains("Unknown class(es) found", "IncorrectM");
+            .when(() -> EqualsVerifier.forPackage(CORRECT_PACKAGE, true).except(IncorrectM.class))
+            .assertThrows(IllegalStateException.class)
+            .assertMessageContains("Unknown class(es) found", "IncorrectM");
     }
 
     @Test
@@ -208,9 +208,9 @@ public class MultipleTypeEqualsVerifierTest {
     @Test
     public void succeed_whenCallingForPackageRecursivelyOnAPackageContainingFailingClasses_givenFailingClassesAreExceptedByPredicate() {
         EqualsVerifier
-                .forPackage(INCORRECT_PACKAGE, true)
-                .except(c -> c.getSimpleName().contains("Incorrect"))
-                .verify();
+            .forPackage(INCORRECT_PACKAGE, true)
+            .except(c -> c.getSimpleName().contains("Incorrect"))
+            .verify();
     }
 
     @Test
@@ -224,9 +224,11 @@ public class MultipleTypeEqualsVerifierTest {
     @Test
     public void fail_whenCallingForPackageRecursivelyOnAPackageContainingFailingClasses_givenFailingClassesAreNotExceptedByPredicate() {
         ExpectedException
-                .when(() -> EqualsVerifier.forPackage(INCORRECT_PACKAGE, true).except(c -> false).verify())
-                .assertFailure()
-                .assertMessageContains("EqualsVerifier found a problem in 4 classes");
+            .when(
+                () -> EqualsVerifier.forPackage(INCORRECT_PACKAGE, true).except(c -> false).verify()
+            )
+            .assertFailure()
+            .assertMessageContains("EqualsVerifier found a problem in 4 classes");
     }
 
     @Test

--- a/src/test/java/nl/jqno/equalsverifier/internal/reflection/PackageScannerTest.java
+++ b/src/test/java/nl/jqno/equalsverifier/internal/reflection/PackageScannerTest.java
@@ -22,7 +22,9 @@ public class PackageScannerTest {
     @Test
     public void happyPath() {
         List<Class<?>> classes = PackageScanner.getClassesIn(
-            "nl.jqno.equalsverifier.testhelpers.packages.correct", false);
+            "nl.jqno.equalsverifier.testhelpers.packages.correct",
+            false
+        );
         classes.sort((a, b) -> a.getName().compareTo(b.getName()));
         assertEquals(Arrays.asList(A.class, B.class, C.class), classes);
     }
@@ -30,9 +32,12 @@ public class PackageScannerTest {
     @Test
     public void happyPathRecursively() {
         List<Class<?>> classes = PackageScanner.getClassesIn(
-                "nl.jqno.equalsverifier.testhelpers.packages.correct", true);
+            "nl.jqno.equalsverifier.testhelpers.packages.correct",
+            true
+        );
         classes.sort(Comparator.comparing(Class::getName));
-        assertEquals(Arrays.asList(
+        assertEquals(
+            Arrays.asList(
                 A.class,
                 B.class,
                 C.class,
@@ -41,13 +46,17 @@ public class PackageScannerTest {
                 nl.jqno.equalsverifier.testhelpers.packages.correct.subpackage.subpackage.A.class,
                 nl.jqno.equalsverifier.testhelpers.packages.correct.subpackage.subpackage.B.class,
                 nl.jqno.equalsverifier.testhelpers.packages.correct.subpackage.subpackage.D.class
-        ), classes);
+            ),
+            classes
+        );
     }
 
     @Test
     public void filterOutTestClasses() {
         List<Class<?>> classes = PackageScanner.getClassesIn(
-            "nl.jqno.equalsverifier.internal.reflection", false);
+            "nl.jqno.equalsverifier.internal.reflection",
+            false
+        );
         List<Class<?>> testClasses = classes
             .stream()
             .filter(c -> c.getName().endsWith("Test"))
@@ -59,11 +68,13 @@ public class PackageScannerTest {
     @Test
     public void filterOutTestClassesRecursively() {
         List<Class<?>> classes = PackageScanner.getClassesIn(
-                "nl.jqno.equalsverifier.internal.reflection", true);
+            "nl.jqno.equalsverifier.internal.reflection",
+            true
+        );
         List<Class<?>> testClasses = classes
-                .stream()
-                .filter(c -> c.getName().endsWith("Test"))
-                .collect(Collectors.toList());
+            .stream()
+            .filter(c -> c.getName().endsWith("Test"))
+            .collect(Collectors.toList());
         assertEquals(Collections.emptyList(), testClasses);
         assertTrue(classes.size() - testClasses.size() > 0);
     }
@@ -71,14 +82,18 @@ public class PackageScannerTest {
     @Test
     public void nonexistentPackage() {
         List<Class<?>> classes = PackageScanner.getClassesIn(
-            "nl.jqno.equalsverifier.nonexistentpackage", false);
+            "nl.jqno.equalsverifier.nonexistentpackage",
+            false
+        );
         assertEquals(Collections.emptyList(), classes);
     }
 
     @Test
     public void nonexistentPackageAndSubPackage() {
         List<Class<?>> classes = PackageScanner.getClassesIn(
-                "nl.jqno.equalsverifier.nonexistentpackage", true);
+            "nl.jqno.equalsverifier.nonexistentpackage",
+            true
+        );
         assertEquals(Collections.emptyList(), classes);
     }
 }

--- a/src/test/java/nl/jqno/equalsverifier/internal/reflection/PackageScannerTest.java
+++ b/src/test/java/nl/jqno/equalsverifier/internal/reflection/PackageScannerTest.java
@@ -6,6 +6,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.Comparator;
 import java.util.List;
 import java.util.stream.Collectors;
 import nl.jqno.equalsverifier.testhelpers.packages.correct.*;
@@ -21,17 +22,32 @@ public class PackageScannerTest {
     @Test
     public void happyPath() {
         List<Class<?>> classes = PackageScanner.getClassesIn(
-            "nl.jqno.equalsverifier.testhelpers.packages.correct"
-        );
+            "nl.jqno.equalsverifier.testhelpers.packages.correct", false);
         classes.sort((a, b) -> a.getName().compareTo(b.getName()));
         assertEquals(Arrays.asList(A.class, B.class, C.class), classes);
     }
 
     @Test
+    public void happyPathRecursively() {
+        List<Class<?>> classes = PackageScanner.getClassesIn(
+                "nl.jqno.equalsverifier.testhelpers.packages.correct", true);
+        classes.sort(Comparator.comparing(Class::getName));
+        assertEquals(Arrays.asList(
+                A.class,
+                B.class,
+                C.class,
+                nl.jqno.equalsverifier.testhelpers.packages.correct.subpackage.A.class,
+                nl.jqno.equalsverifier.testhelpers.packages.correct.subpackage.B.class,
+                nl.jqno.equalsverifier.testhelpers.packages.correct.subpackage.subpackage.A.class,
+                nl.jqno.equalsverifier.testhelpers.packages.correct.subpackage.subpackage.B.class,
+                nl.jqno.equalsverifier.testhelpers.packages.correct.subpackage.subpackage.D.class
+        ), classes);
+    }
+
+    @Test
     public void filterOutTestClasses() {
         List<Class<?>> classes = PackageScanner.getClassesIn(
-            "nl.jqno.equalsverifier.internal.reflection"
-        );
+            "nl.jqno.equalsverifier.internal.reflection", false);
         List<Class<?>> testClasses = classes
             .stream()
             .filter(c -> c.getName().endsWith("Test"))
@@ -41,10 +57,28 @@ public class PackageScannerTest {
     }
 
     @Test
+    public void filterOutTestClassesRecursively() {
+        List<Class<?>> classes = PackageScanner.getClassesIn(
+                "nl.jqno.equalsverifier.internal.reflection", true);
+        List<Class<?>> testClasses = classes
+                .stream()
+                .filter(c -> c.getName().endsWith("Test"))
+                .collect(Collectors.toList());
+        assertEquals(Collections.emptyList(), testClasses);
+        assertTrue(classes.size() - testClasses.size() > 0);
+    }
+
+    @Test
     public void nonexistentPackage() {
         List<Class<?>> classes = PackageScanner.getClassesIn(
-            "nl.jqno.equalsverifier.nonexistentpackage"
-        );
+            "nl.jqno.equalsverifier.nonexistentpackage", false);
+        assertEquals(Collections.emptyList(), classes);
+    }
+
+    @Test
+    public void nonexistentPackageAndSubPackage() {
+        List<Class<?>> classes = PackageScanner.getClassesIn(
+                "nl.jqno.equalsverifier.nonexistentpackage", true);
         assertEquals(Collections.emptyList(), classes);
     }
 }

--- a/src/test/java/nl/jqno/equalsverifier/testhelpers/packages/correct/subpackage/A.java
+++ b/src/test/java/nl/jqno/equalsverifier/testhelpers/packages/correct/subpackage/A.java
@@ -1,0 +1,31 @@
+package nl.jqno.equalsverifier.testhelpers.packages.correct.subpackage;
+
+public final class A {
+
+    private final int x;
+    private final int y;
+
+    public A(int x, int y) {
+        this.x = x;
+        this.y = y;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (!(obj instanceof A)) {
+            return false;
+        }
+        A p = (A) obj;
+        return p.x == x && p.y == y;
+    }
+
+    @Override
+    public int hashCode() {
+        return x + (31 * y);
+    }
+
+    @Override
+    public String toString() {
+        return getClass().getSimpleName() + ":" + x + "," + y;
+    }
+}

--- a/src/test/java/nl/jqno/equalsverifier/testhelpers/packages/correct/subpackage/B.java
+++ b/src/test/java/nl/jqno/equalsverifier/testhelpers/packages/correct/subpackage/B.java
@@ -1,0 +1,31 @@
+package nl.jqno.equalsverifier.testhelpers.packages.correct.subpackage;
+
+public final class B {
+
+    private final int x;
+    private final int y;
+
+    public B(int x, int y) {
+        this.x = x;
+        this.y = y;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (!(obj instanceof B)) {
+            return false;
+        }
+        B p = (B) obj;
+        return p.x == x && p.y == y;
+    }
+
+    @Override
+    public int hashCode() {
+        return x + (31 * y);
+    }
+
+    @Override
+    public String toString() {
+        return getClass().getSimpleName() + ":" + x + "," + y;
+    }
+}

--- a/src/test/java/nl/jqno/equalsverifier/testhelpers/packages/correct/subpackage/subpackage/A.java
+++ b/src/test/java/nl/jqno/equalsverifier/testhelpers/packages/correct/subpackage/subpackage/A.java
@@ -1,0 +1,31 @@
+package nl.jqno.equalsverifier.testhelpers.packages.correct.subpackage.subpackage;
+
+public final class A {
+
+    private final int x;
+    private final int y;
+
+    public A(int x, int y) {
+        this.x = x;
+        this.y = y;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (!(obj instanceof A)) {
+            return false;
+        }
+        A p = (A) obj;
+        return p.x == x && p.y == y;
+    }
+
+    @Override
+    public int hashCode() {
+        return x + (31 * y);
+    }
+
+    @Override
+    public String toString() {
+        return getClass().getSimpleName() + ":" + x + "," + y;
+    }
+}

--- a/src/test/java/nl/jqno/equalsverifier/testhelpers/packages/correct/subpackage/subpackage/B.java
+++ b/src/test/java/nl/jqno/equalsverifier/testhelpers/packages/correct/subpackage/subpackage/B.java
@@ -1,0 +1,31 @@
+package nl.jqno.equalsverifier.testhelpers.packages.correct.subpackage.subpackage;
+
+public final class B {
+
+    private final int x;
+    private final int y;
+
+    public B(int x, int y) {
+        this.x = x;
+        this.y = y;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (!(obj instanceof B)) {
+            return false;
+        }
+        B p = (B) obj;
+        return p.x == x && p.y == y;
+    }
+
+    @Override
+    public int hashCode() {
+        return x + (31 * y);
+    }
+
+    @Override
+    public String toString() {
+        return getClass().getSimpleName() + ":" + x + "," + y;
+    }
+}

--- a/src/test/java/nl/jqno/equalsverifier/testhelpers/packages/correct/subpackage/subpackage/D.java
+++ b/src/test/java/nl/jqno/equalsverifier/testhelpers/packages/correct/subpackage/subpackage/D.java
@@ -1,0 +1,31 @@
+package nl.jqno.equalsverifier.testhelpers.packages.correct.subpackage.subpackage;
+
+public final class D {
+
+    private final int x;
+    private final int y;
+
+    public D(int x, int y) {
+        this.x = x;
+        this.y = y;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (!(obj instanceof D)) {
+            return false;
+        }
+        D p = (D) obj;
+        return p.x == x && p.y == y;
+    }
+
+    @Override
+    public int hashCode() {
+        return x + (31 * y);
+    }
+
+    @Override
+    public String toString() {
+        return getClass().getSimpleName() + ":" + x + "," + y;
+    }
+}

--- a/src/test/java/nl/jqno/equalsverifier/testhelpers/packages/twoincorrect/subpackage/IncorrectO.java
+++ b/src/test/java/nl/jqno/equalsverifier/testhelpers/packages/twoincorrect/subpackage/IncorrectO.java
@@ -1,0 +1,31 @@
+package nl.jqno.equalsverifier.testhelpers.packages.twoincorrect.subpackage;
+
+public class IncorrectO {
+
+    private final int x;
+    private final int y;
+
+    public IncorrectO(int x, int y) {
+        this.x = x;
+        this.y = y;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (!(obj instanceof IncorrectO)) {
+            return false;
+        }
+        IncorrectO p = (IncorrectO) obj;
+        return p.x == x && p.y == y;
+    }
+
+    @Override
+    public int hashCode() {
+        return x + (31 * y);
+    }
+
+    @Override
+    public String toString() {
+        return getClass().getSimpleName() + ":" + x + "," + y;
+    }
+}

--- a/src/test/java/nl/jqno/equalsverifier/testhelpers/packages/twoincorrect/subpackage/IncorrectP.java
+++ b/src/test/java/nl/jqno/equalsverifier/testhelpers/packages/twoincorrect/subpackage/IncorrectP.java
@@ -1,0 +1,31 @@
+package nl.jqno.equalsverifier.testhelpers.packages.twoincorrect.subpackage;
+
+public final class IncorrectP {
+
+    private final int x;
+    private final int y;
+
+    public IncorrectP(int x, int y) {
+        this.x = x;
+        this.y = y;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (!(obj instanceof IncorrectP)) {
+            return false;
+        }
+        IncorrectP p = (IncorrectP) obj;
+        return p.x == x && p.y != y;
+    }
+
+    @Override
+    public int hashCode() {
+        return x + (31 * y);
+    }
+
+    @Override
+    public String toString() {
+        return getClass().getSimpleName() + ":" + x + "," + y;
+    }
+}


### PR DESCRIPTION
I added a new method `EqualsVerifier.forPackage(String packageName, boolean scanRecursively)` to verify a given package and all sub-packages.

This is useful when we organize our beans with sub-packages and don't want to forget to test a sub-package.

To String Verifier project offers an equivalent method: 
https://github.com/jparams/to-string-verifier/blob/c5b1c6666d78b5fc7c9b07e81d48582b4d34fcb4/src/main/java/com/jparams/verifier/tostring/ToStringVerifier.java#L117