### PR TITLE
fix scanning package recursively when we create a 'simple' configuration

### DIFF
--- a/src/main/java/nl/jqno/equalsverifier/ConfiguredEqualsVerifier.java
+++ b/src/main/java/nl/jqno/equalsverifier/ConfiguredEqualsVerifier.java
@@ -162,6 +162,6 @@ public final class ConfiguredEqualsVerifier implements EqualsVerifierApi<Void> {
     public MultipleTypeEqualsVerifierApi forPackage(String packageName, boolean scanRecursively) {
         List<Class<?>> classes = PackageScanner.getClassesIn(packageName, scanRecursively);
         Validations.validatePackageContainsClasses(packageName, classes);
-        return new MultipleTypeEqualsVerifierApi(classes, new ConfiguredEqualsVerifier());
+        return new MultipleTypeEqualsVerifierApi(classes, this);
     }
 }

--- a/src/test/java/nl/jqno/equalsverifier/integration/extra_features/SimpleEqualsVerifierTest.java
+++ b/src/test/java/nl/jqno/equalsverifier/integration/extra_features/SimpleEqualsVerifierTest.java
@@ -15,9 +15,33 @@ public class SimpleEqualsVerifierTest {
     }
 
     @Test
+    public void succeed_whenTestingGeneratedClassesRecursively_givenASimpleEqualsVerifier() {
+        EqualsVerifier
+            .simple()
+            .forPackage("nl.jqno.equalsverifier.integration.extra_features.simple_package", true)
+            .verify();
+    }
+
+    @Test
     public void mentionSimple_whenTestingGeneratedClass_givenNothingSpecial() {
         ExpectedException
             .when(() -> EqualsVerifier.forClass(IntelliJPoint.class).verify())
+            .assertFailure()
+            .assertMessageContains("or use EqualsVerifier.simple()");
+    }
+
+    @Test
+    public void mentionSimple_whenTestingGeneratedClassesRecursively_givenNothingSpecial() {
+        ExpectedException
+            .when(
+                () ->
+                    EqualsVerifier
+                        .forPackage(
+                            "nl.jqno.equalsverifier.integration.extra_features.simple_package",
+                            true
+                        )
+                        .verify()
+            )
             .assertFailure()
             .assertMessageContains("or use EqualsVerifier.simple()");
     }

--- a/src/test/java/nl/jqno/equalsverifier/integration/extra_features/simple_package/IntelliJPoint1.java
+++ b/src/test/java/nl/jqno/equalsverifier/integration/extra_features/simple_package/IntelliJPoint1.java
@@ -1,0 +1,32 @@
+package nl.jqno.equalsverifier.integration.extra_features.simple_package;
+
+import java.util.Objects;
+import nl.jqno.equalsverifier.testhelpers.types.Color;
+
+public class IntelliJPoint1 {
+
+    private int x;
+    private int y;
+    private Color color;
+
+    public IntelliJPoint1(int x) {
+        this.x = x;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        IntelliJPoint1 that = (IntelliJPoint1) o;
+        return x == that.x && y == that.y && color == that.color;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(x, y, color);
+    }
+}

--- a/src/test/java/nl/jqno/equalsverifier/integration/extra_features/simple_package/subpackage/IntelliJPoint2.java
+++ b/src/test/java/nl/jqno/equalsverifier/integration/extra_features/simple_package/subpackage/IntelliJPoint2.java
@@ -1,0 +1,32 @@
+package nl.jqno.equalsverifier.integration.extra_features.simple_package.subpackage;
+
+import java.util.Objects;
+import nl.jqno.equalsverifier.testhelpers.types.Color;
+
+public class IntelliJPoint2 {
+
+    private int x;
+    private int y;
+    private Color color;
+
+    public IntelliJPoint2(int x) {
+        this.x = x;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        IntelliJPoint2 that = (IntelliJPoint2) o;
+        return x == that.x && y == that.y && color == that.color;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(x, y, color);
+    }
+}


### PR DESCRIPTION
# What problem does this pull request solve?
EqualsVerifier
            .simple()
            .forPackage("nl.jqno.equalsverifier.integration.extra_features.simple_package", true)
            .verify();

This doesn't work because `ConfiguredEqualsVerifier.forPackage(...)` creates a new instance of `ConfiguredEqualsVerifier`, instead of `this`