### PR TITLE
Skip anonymous and local classes when scanning a package

### DIFF
--- a/src/main/java/nl/jqno/equalsverifier/internal/reflection/PackageScanner.java
+++ b/src/main/java/nl/jqno/equalsverifier/internal/reflection/PackageScanner.java
@@ -62,6 +62,8 @@ public final class PackageScanner {
                 }
                 return classes.stream();
             })
+            .filter(c -> !c.isAnonymousClass())
+            .filter(c -> !c.isLocalClass())
             .filter(c -> !c.getName().endsWith("Test"))
             .collect(Collectors.toList());
     }

--- a/src/test/java/nl/jqno/equalsverifier/internal/reflection/PackageScannerTest.java
+++ b/src/test/java/nl/jqno/equalsverifier/internal/reflection/PackageScannerTest.java
@@ -96,4 +96,19 @@ public class PackageScannerTest {
         );
         assertEquals(Collections.emptyList(), classes);
     }
+
+    @Test
+    public void anonymousAndLocalClassesAreSkipped() {
+        List<Class<?>> classes = PackageScanner.getClassesIn(
+            "nl.jqno.equalsverifier.testhelpers.packages.anonymous",
+            false
+        );
+
+        assertEquals(
+            Collections.singletonList(
+                nl.jqno.equalsverifier.testhelpers.packages.anonymous.A.class
+            ),
+            classes
+        );
+    }
 }

--- a/src/test/java/nl/jqno/equalsverifier/testhelpers/packages/anonymous/A.java
+++ b/src/test/java/nl/jqno/equalsverifier/testhelpers/packages/anonymous/A.java
@@ -1,0 +1,50 @@
+package nl.jqno.equalsverifier.testhelpers.packages.anonymous;
+
+import java.util.function.Supplier;
+
+public final class A {
+
+    private final int x;
+    private final int y;
+
+    public A(int x, int y) {
+        this.x = x;
+        this.y = y;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (!(obj instanceof A)) {
+            return false;
+        }
+        A p = (A) obj;
+        return p.x == x && p.y == y;
+    }
+
+    @Override
+    public int hashCode() {
+        return x + (31 * y);
+    }
+
+    @Override
+    public String toString() {
+        return getClass().getSimpleName() + ":" + x + "," + y;
+    }
+
+    public static void anonymousClass() {
+        new Supplier<String>() {
+            @Override
+            public String get() {
+                return "";
+            }
+        };
+    }
+
+    public static void localClass() {
+        class Local {
+
+            int x;
+            int y;
+        }
+    }
+}


### PR DESCRIPTION
Attempting to run EqualsVerifier on a package with classes containing
inner anonymous or local classes would result in spurious failures.

Fix for #517 