### PR TITLE
ci: use 'temurin' instead of 'adopt'

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,19 +13,19 @@ jobs:
             continue-on-error: false
             cache-id: "jdk8"
             java: 8
-            dist: adopt
+            dist: temurin
             flags: "-DdisableStaticAnalysis"
           - title: "Supported JDK 11"
             continue-on-error: false
             cache-id: "jdk11"
             java: 11
-            dist: adopt
+            dist: temurin
             flags: ""
           - title: "Supported JDK 17"
             continue-on-error: false
             cache-id: "jdk17"
             java: 17
-            dist: adopt
+            dist: temurin
             flags: ""
           - title: "Experimental JDK EA (simplified)"
             continue-on-error: false

--- a/.github/workflows/pitest-comment.yml
+++ b/.github/workflows/pitest-comment.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Set up JDK 11
         uses: actions/setup-java@v2
         with:
-          distribution: 'adopt'
+          distribution: 'temurin'
           java-version: 11
       - name: Download artifact
         uses: dawidd6/action-download-artifact@v2
@@ -38,6 +38,6 @@ jobs:
           workflow_conclusion: success
       - name: update pull request
         # The updatePR maven goal is used here with an explicit version. This allows us to upload without checking out
-        # the code, but does mean the version here must be maintained. An alternative would be to checkout the code and use 
+        # the code, but does mean the version here must be maintained. An alternative would be to checkout the code and use
         # the github goal. This will work as long as the artifact is extracted to the maven target directory
         run: mvn -DrepoToken=${{ secrets.GITHUB_TOKEN }} com.groupcdg:pitest-github-maven-plugin:0.1.0:updatePR

--- a/.github/workflows/pitest.yml
+++ b/.github/workflows/pitest.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Set up JDK 11
         uses: actions/setup-java@v2
         with:
-          distribution: 'adopt'
+          distribution: 'temurin'
           java-version: 11
       - name: run pitest
         # pitest has been bound to a profile called pitest for normal running


### PR DESCRIPTION

# What problem does this pull request solve?

https://github.com/actions/setup-java/blob/main/README.md

"It is highly recommended to migrate workflows from adopt
to temurin to keep receiving software and security updates."

# Please provide any additional information below.

# NOTE
* Please run `mvn spotless:apply` to format the code before opening a PR. Otherwise, GitHub Actions will complain at you 😉. Unfortunately, you will need to have Node installed to do so.
* Mutation tests will be run by [PITest](https://pitest.org/) after opening the PR. It will post comments in the PR for each issue found. Please take a look at them, but if the comments don't make sense, please don't worry about them.

