### PR TITLE
Adds support for jakarta persistence annotations

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -143,6 +143,12 @@
             <version>2.2.600</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>jakarta.persistence</groupId>
+            <artifactId>jakarta.persistence-api</artifactId>
+            <version>3.0.0</version>
+            <scope>test</scope>
+        </dependency>
 
         <!-- ArchUnit dependencies -->
         <dependency>

--- a/src/main/java/nl/jqno/equalsverifier/internal/reflection/annotations/SupportedAnnotations.java
+++ b/src/main/java/nl/jqno/equalsverifier/internal/reflection/annotations/SupportedAnnotations.java
@@ -150,7 +150,10 @@ public enum SupportedAnnotations implements Annotation {
         false,
         "javax.persistence.Entity",
         "javax.persistence.Embeddable",
-        "javax.persistence.MappedSuperclass"
+        "javax.persistence.MappedSuperclass",
+        "jakarta.persistence.Entity",
+        "jakarta.persistence.Embeddable",
+        "jakarta.persistence.MappedSuperclass"
     ),
 
     /**
@@ -158,14 +161,20 @@ public enum SupportedAnnotations implements Annotation {
      * equals/hashCode contract, like fields that have the Java transient modifier. EqualsVerifier
      * will treat these the same.
      */
-    TRANSIENT(true, "javax.persistence.Transient"),
+    TRANSIENT(true, "javax.persistence.Transient", "jakarta.persistence.Transient"),
 
     /**
      * Fields in JPA Entities that are marked @Id or @EmbeddedId are usually part of the entity's
      * surrogate key. EqualsVerifier will therefore assume that it must not be used in the
      * equals/hashCode contract, unless {@link Warning#SURROGATE_KEY} is suppressed.
      */
-    ID(false, "javax.persistence.Id", "javax.persistence.EmbeddedId") {
+    ID(
+        false,
+        "javax.persistence.Id",
+        "javax.persistence.EmbeddedId",
+        "jakarta.persistence.Id",
+        "jakarta.persistence.EmbeddedId"
+    ) {
         @Override
         public void postProcess(Set<Class<?>> types, AnnotationCache annotationCache) {
             types.forEach(t -> annotationCache.addClassAnnotation(t, ID));

--- a/src/test/java/nl/jqno/equalsverifier/integration/extra_features/JakartaEntityTest.java
+++ b/src/test/java/nl/jqno/equalsverifier/integration/extra_features/JakartaEntityTest.java
@@ -1,0 +1,148 @@
+package nl.jqno.equalsverifier.integration.extra_features;
+
+import static nl.jqno.equalsverifier.testhelpers.Util.defaultHashCode;
+
+import java.util.Objects;
+import nl.jqno.equalsverifier.EqualsVerifier;
+import nl.jqno.equalsverifier.testhelpers.ExpectedException;
+import org.junit.jupiter.api.Test;
+
+public class JakartaEntityTest {
+
+    @Test
+    public void succeed_whenClassIsNonFinalAndFieldsAreMutable_givenClassHasJpaEntityAnnotation() {
+        EqualsVerifier.forClass(EntityByJakartaAnnotation.class).verify();
+    }
+
+    @Test
+    public void fail_whenClassIsNonFinalAndFieldsAreMutable_givenSuperclassHasJpaEntityAnnotationButThisClassDoesnt() {
+        ExpectedException
+            .when(() -> EqualsVerifier.forClass(SubclassEntityByJakartaAnnotation.class).verify())
+            .assertFailure()
+            .assertMessageContains("Subclass");
+    }
+
+    @Test
+    public void succeed_whenFieldsAreMutable_givenClassHasJpaEmbeddableAnnotation() {
+        EqualsVerifier.forClass(EmbeddableByJakartaAnnotation.class).verify();
+    }
+
+    @Test
+    public void fail_whenFieldsAreMutable_givenSuperclassHasJpaEmbeddableAnnotationButThisClassDoesnt() {
+        ExpectedException
+            .when(() ->
+                EqualsVerifier.forClass(SubclassEmbeddableByJakartaAnnotation.class).verify()
+            )
+            .assertFailure()
+            .assertMessageContains("Subclass");
+    }
+
+    @Test
+    public void succeed_whenFieldsAreMutable_givenClassHasJpaMappedSuperclassAnnotation() {
+        EqualsVerifier.forClass(MappedSuperclassByJakartaAnnotation.class).verify();
+    }
+
+    @Test
+    public void fail_whenFieldsAreMutable_givenSuperclassHasJpaMappedSuperclassAnnotationButThisClassDoesnt() {
+        ExpectedException
+            .when(() ->
+                EqualsVerifier.forClass(SubclassMappedSuperclassByJakartaAnnotation.class).verify()
+            )
+            .assertFailure()
+            .assertMessageContains("Subclass");
+    }
+
+    @jakarta.persistence.Entity
+    static class EntityByJakartaAnnotation {
+
+        private int i;
+        private String s;
+
+        public void setI(int value) {
+            this.i = value;
+        }
+
+        public void setS(String value) {
+            this.s = value;
+        }
+
+        @Override
+        public boolean equals(Object obj) {
+            if (!(obj instanceof EntityByJakartaAnnotation)) {
+                return false;
+            }
+            EntityByJakartaAnnotation other = (EntityByJakartaAnnotation) obj;
+            return i == other.i && Objects.equals(s, other.s);
+        }
+
+        @Override
+        public int hashCode() {
+            return defaultHashCode(this);
+        }
+    }
+
+    static class SubclassEntityByJakartaAnnotation extends EntityByJakartaAnnotation {}
+
+    @jakarta.persistence.Embeddable
+    static class EmbeddableByJakartaAnnotation {
+
+        private int i;
+        private String s;
+
+        public void setI(int value) {
+            this.i = value;
+        }
+
+        public void setS(String value) {
+            this.s = value;
+        }
+
+        @Override
+        public boolean equals(Object obj) {
+            if (!(obj instanceof EmbeddableByJakartaAnnotation)) {
+                return false;
+            }
+            EmbeddableByJakartaAnnotation other = (EmbeddableByJakartaAnnotation) obj;
+            return i == other.i && Objects.equals(s, other.s);
+        }
+
+        @Override
+        public int hashCode() {
+            return defaultHashCode(this);
+        }
+    }
+
+    static class SubclassEmbeddableByJakartaAnnotation extends EmbeddableByJakartaAnnotation {}
+
+    @jakarta.persistence.MappedSuperclass
+    abstract static class MappedSuperclassByJakartaAnnotation {
+
+        private int i;
+        private String s;
+
+        public void setI(int value) {
+            this.i = value;
+        }
+
+        public void setS(String value) {
+            this.s = value;
+        }
+
+        @Override
+        public boolean equals(Object obj) {
+            if (!(obj instanceof MappedSuperclassByJakartaAnnotation)) {
+                return false;
+            }
+            MappedSuperclassByJakartaAnnotation other = (MappedSuperclassByJakartaAnnotation) obj;
+            return i == other.i && Objects.equals(s, other.s);
+        }
+
+        @Override
+        public int hashCode() {
+            return defaultHashCode(this);
+        }
+    }
+
+    static class SubclassMappedSuperclassByJakartaAnnotation
+        extends MappedSuperclassByJakartaAnnotation {}
+}

--- a/src/test/java/nl/jqno/equalsverifier/integration/extra_features/JakartaIdTest.java
+++ b/src/test/java/nl/jqno/equalsverifier/integration/extra_features/JakartaIdTest.java
@@ -14,18 +14,18 @@ public class JakartaIdTest {
 
     @Test
     public void succeed_whenIdFieldIsNotUsed_givenIdIsAnnotatedWithId() {
-        EqualsVerifier.forClass(JpaIdBusinessKeyPerson.class).verify();
-        EqualsVerifier.forClass(JpaIdBusinessKeyPersonReorderedFields.class).verify();
+        EqualsVerifier.forClass(JakartaIdBusinessKeyPerson.class).verify();
+        EqualsVerifier.forClass(JakartaIdBusinessKeyPersonReorderedFields.class).verify();
     }
 
     @Test
     public void succeed_whenOnlyIdFieldIsUsed_givenIdIsAnnotatedWithIdAndSurrogateKeyWarningIsSuppressed() {
         EqualsVerifier
-            .forClass(JpaIdSurrogateKeyPerson.class)
+            .forClass(JakartaIdSurrogateKeyPerson.class)
             .suppress(Warning.SURROGATE_KEY)
             .verify();
         EqualsVerifier
-            .forClass(JpaIdSurrogateKeyPersonReorderedFields.class)
+            .forClass(JakartaIdSurrogateKeyPersonReorderedFields.class)
             .suppress(Warning.SURROGATE_KEY)
             .verify();
     }
@@ -35,7 +35,7 @@ public class JakartaIdTest {
         ExpectedException
             .when(() ->
                 EqualsVerifier
-                    .forClass(JpaIdBusinessKeyPerson.class)
+                    .forClass(JakartaIdBusinessKeyPerson.class)
                     .withIgnoredAnnotations(jakarta.persistence.Id.class)
                     .verify()
             )
@@ -46,7 +46,7 @@ public class JakartaIdTest {
     @Test
     public void fail_whenOnlyIdFieldIsUsed_givenIdIsAnnotatedWithId() {
         ExpectedException
-            .when(() -> EqualsVerifier.forClass(JpaIdSurrogateKeyPerson.class).verify())
+            .when(() -> EqualsVerifier.forClass(JakartaIdSurrogateKeyPerson.class).verify())
             .assertFailure()
             .assertMessageContains(
                 "Significant fields",
@@ -60,7 +60,7 @@ public class JakartaIdTest {
     public void fail_whenOnlyIdFieldIsUsed_givenIdIsAnnotatedWithId2() {
         ExpectedException
             .when(() ->
-                EqualsVerifier.forClass(JpaIdSurrogateKeyPersonReorderedFields.class).verify()
+                EqualsVerifier.forClass(JakartaIdSurrogateKeyPersonReorderedFields.class).verify()
             )
             .assertFailure()
             .assertMessageContains(
@@ -75,7 +75,7 @@ public class JakartaIdTest {
         ExpectedException
             .when(() ->
                 EqualsVerifier
-                    .forClass(JpaIdBusinessKeyPerson.class)
+                    .forClass(JakartaIdBusinessKeyPerson.class)
                     .suppress(Warning.SURROGATE_KEY)
                     .verify()
             )
@@ -93,7 +93,7 @@ public class JakartaIdTest {
         ExpectedException
             .when(() ->
                 EqualsVerifier
-                    .forClass(JpaIdBusinessKeyPersonReorderedFields.class)
+                    .forClass(JakartaIdBusinessKeyPersonReorderedFields.class)
                     .suppress(Warning.SURROGATE_KEY)
                     .verify()
             )
@@ -108,9 +108,9 @@ public class JakartaIdTest {
 
     @Test
     public void succeed_whenEmbeddedIdIsUsedCorrectly() {
-        EqualsVerifier.forClass(JpaEmbeddedIdBusinessKeyPerson.class).verify();
+        EqualsVerifier.forClass(JakartaEmbeddedIdBusinessKeyPerson.class).verify();
         EqualsVerifier
-            .forClass(JpaEmbeddedIdSurrogateKeyPerson.class)
+            .forClass(JakartaEmbeddedIdSurrogateKeyPerson.class)
             .suppress(Warning.SURROGATE_KEY)
             .verify();
     }
@@ -118,7 +118,7 @@ public class JakartaIdTest {
     @Test
     public void fail_whenOnlyEmbeddedIdFieldIsUsed_givenIdIsAnnotatedWithEmbeddedId() {
         ExpectedException
-            .when(() -> EqualsVerifier.forClass(JpaEmbeddedIdSurrogateKeyPerson.class).verify())
+            .when(() -> EqualsVerifier.forClass(JakartaEmbeddedIdSurrogateKeyPerson.class).verify())
             .assertFailure()
             .assertMessageContains(
                 "Significant fields",
@@ -133,7 +133,7 @@ public class JakartaIdTest {
         ExpectedException
             .when(() ->
                 EqualsVerifier
-                    .forClass(JpaEmbeddedIdBusinessKeyPerson.class)
+                    .forClass(JakartaEmbeddedIdBusinessKeyPerson.class)
                     .suppress(Warning.SURROGATE_KEY)
                     .verify()
             )
@@ -151,7 +151,7 @@ public class JakartaIdTest {
         ExpectedException
             .when(() ->
                 EqualsVerifier
-                    .forClass(JpaEmbeddedIdBusinessKeyPerson.class)
+                    .forClass(JakartaEmbeddedIdBusinessKeyPerson.class)
                     .withOnlyTheseFields("id")
                     .verify()
             )
@@ -165,11 +165,6 @@ public class JakartaIdTest {
     @Test
     public void succeed_whenOnlySocialSecurityIsUsed_givenSocialSecurityIsAnnotatedWithNaturalId() {
         EqualsVerifier.forClass(NaturalIdBusinessKeyPerson.class).verify();
-    }
-
-    @Test
-    public void succeed_whenOnlySocialSecurityIsUsed_givenSocialSecurityIsAnnotatedWithNaturalIdAndNothingIsAnnotatedWithJpaId() {
-        EqualsVerifier.forClass(NaturalIdWithoutJpaIdBusinessKeyPerson.class).verify();
     }
 
     @Test
@@ -188,7 +183,7 @@ public class JakartaIdTest {
     @Test
     public void succeed_whenIdAndNameFieldsAreNotUsed_givenNameIsIgnored() {
         EqualsVerifier
-            .forClass(JpaIdBusinessKeyPersonDoesntUseName.class)
+            .forClass(JakartaIdBusinessKeyPersonDoesntUseName.class)
             .withIgnoredFields("name")
             .verify();
     }
@@ -196,25 +191,25 @@ public class JakartaIdTest {
     @Test
     public void succeed_whenIdAndNameFieldsAreNotUsed_givenSocialSecurityAndBirthdateAreOnlyUsed() {
         EqualsVerifier
-            .forClass(JpaIdBusinessKeyPersonDoesntUseName.class)
+            .forClass(JakartaIdBusinessKeyPersonDoesntUseName.class)
             .withOnlyTheseFields("socialSecurity", "birthdate")
             .verify();
     }
 
     @Test
-    public void succeed_whenIdIsPartOfAProperJpaEntity() {
-        EqualsVerifier.forClass(JpaIdBusinessKeyPersonEntity.class).verify();
+    public void succeed_whenIdIsPartOfAProperJakartaEntity() {
+        EqualsVerifier.forClass(JakartaIdBusinessKeyPersonEntity.class).verify();
     }
 
     @Test
-    public void succeed_whenNaturalIdIsPartOfAProperJpaEntity() {
+    public void succeed_whenNaturalIdIsPartOfAProperJakartaEntity() {
         EqualsVerifier.forClass(NaturalIdBusinessKeyPersonEntity.class).verify();
     }
 
     @Test
     public void succeed_whenEqualsBehavesLikeVersionedEntity_givenIdIsMarkedWithIdAndWarningVersionedEntityIsSuppressed() {
         EqualsVerifier
-            .forClass(JpaIdVersionedEntity.class)
+            .forClass(JakartaIdVersionedEntity.class)
             .suppress(Warning.IDENTICAL_COPY_FOR_VERSIONED_ENTITY)
             .verify();
     }
@@ -229,7 +224,7 @@ public class JakartaIdTest {
         ExpectedException
             .when(() ->
                 EqualsVerifier
-                    .forClass(JpaIdBusinessKeyPerson.class)
+                    .forClass(JakartaIdBusinessKeyPerson.class)
                     .withOnlyTheseFields("id")
                     .verify()
             )
@@ -260,7 +255,7 @@ public class JakartaIdTest {
         ExpectedException
             .when(() ->
                 EqualsVerifier
-                    .forClass(JpaIdSurrogateKeyPerson.class)
+                    .forClass(JakartaIdSurrogateKeyPerson.class)
                     .withOnlyTheseFields("socialSecurity")
                     .suppress(Warning.SURROGATE_KEY)
             )
@@ -276,7 +271,7 @@ public class JakartaIdTest {
         ExpectedException
             .when(() ->
                 EqualsVerifier
-                    .forClass(JpaIdSurrogateKeyPerson.class)
+                    .forClass(JakartaIdSurrogateKeyPerson.class)
                     .suppress(Warning.SURROGATE_KEY)
                     .withOnlyTheseFields("socialSecurity")
             )
@@ -292,7 +287,7 @@ public class JakartaIdTest {
         ExpectedException
             .when(() ->
                 EqualsVerifier
-                    .forClass(JpaIdSurrogateKeyPerson.class)
+                    .forClass(JakartaIdSurrogateKeyPerson.class)
                     .withIgnoredFields("socialSecurity")
                     .suppress(Warning.SURROGATE_KEY)
             )
@@ -307,7 +302,7 @@ public class JakartaIdTest {
         ExpectedException
             .when(() ->
                 EqualsVerifier
-                    .forClass(JpaIdSurrogateKeyPerson.class)
+                    .forClass(JakartaIdSurrogateKeyPerson.class)
                     .suppress(Warning.SURROGATE_KEY)
                     .withIgnoredFields("socialSecurity")
             )
@@ -367,7 +362,7 @@ public class JakartaIdTest {
         ExpectedException
             .when(() ->
                 EqualsVerifier
-                    .forClass(JpaIdBusinessKeyPerson.class)
+                    .forClass(JakartaIdBusinessKeyPerson.class)
                     .suppress(Warning.SURROGATE_KEY, Warning.IDENTICAL_COPY_FOR_VERSIONED_ENTITY)
             )
             .assertThrows(IllegalStateException.class)
@@ -375,14 +370,6 @@ public class JakartaIdTest {
                 "Precondition",
                 "you can't suppress Warning.IDENTICAL_COPY_FOR_VERSIONED_ENTITY when Warning.SURROGATE_KEY is also suppressed."
             );
-    }
-
-    @Test
-    public void fail_whenAnIdAnnotationFromAnotherPackageIsUsed() {
-        ExpectedException
-            .when(() -> EqualsVerifier.forClass(NonJpaIdBusinessKeyPerson.class).verify())
-            .assertFailure()
-            .assertMessageContains("Significant fields");
     }
 
     @Test
@@ -395,7 +382,7 @@ public class JakartaIdTest {
             .assertMessageContains("Significant fields");
     }
 
-    static final class JpaIdBusinessKeyPerson {
+    static final class JakartaIdBusinessKeyPerson {
 
         @jakarta.persistence.Id
         private final UUID id;
@@ -404,7 +391,7 @@ public class JakartaIdTest {
         private final String name;
         private final LocalDate birthdate;
 
-        public JpaIdBusinessKeyPerson(
+        public JakartaIdBusinessKeyPerson(
             UUID id,
             String socialSecurity,
             String name,
@@ -418,10 +405,10 @@ public class JakartaIdTest {
 
         @Override
         public boolean equals(Object obj) {
-            if (!(obj instanceof JpaIdBusinessKeyPerson)) {
+            if (!(obj instanceof JakartaIdBusinessKeyPerson)) {
                 return false;
             }
-            JpaIdBusinessKeyPerson other = (JpaIdBusinessKeyPerson) obj;
+            JakartaIdBusinessKeyPerson other = (JakartaIdBusinessKeyPerson) obj;
             return (
                 Objects.equals(socialSecurity, other.socialSecurity) &&
                 Objects.equals(name, other.name) &&
@@ -435,7 +422,7 @@ public class JakartaIdTest {
         }
     }
 
-    static final class JpaIdBusinessKeyPersonReorderedFields {
+    static final class JakartaIdBusinessKeyPersonReorderedFields {
 
         private final String socialSecurity;
         private final String name;
@@ -444,7 +431,7 @@ public class JakartaIdTest {
         @jakarta.persistence.Id
         private final UUID id;
 
-        public JpaIdBusinessKeyPersonReorderedFields(
+        public JakartaIdBusinessKeyPersonReorderedFields(
             UUID id,
             String socialSecurity,
             String name,
@@ -458,10 +445,10 @@ public class JakartaIdTest {
 
         @Override
         public boolean equals(Object obj) {
-            if (!(obj instanceof JpaIdBusinessKeyPersonReorderedFields)) {
+            if (!(obj instanceof JakartaIdBusinessKeyPersonReorderedFields)) {
                 return false;
             }
-            JpaIdBusinessKeyPersonReorderedFields other = (JpaIdBusinessKeyPersonReorderedFields) obj;
+            JakartaIdBusinessKeyPersonReorderedFields other = (JakartaIdBusinessKeyPersonReorderedFields) obj;
             return (
                 Objects.equals(socialSecurity, other.socialSecurity) &&
                 Objects.equals(name, other.name) &&
@@ -475,7 +462,7 @@ public class JakartaIdTest {
         }
     }
 
-    static final class JpaIdSurrogateKeyPerson {
+    static final class JakartaIdSurrogateKeyPerson {
 
         @jakarta.persistence.Id
         private final UUID id;
@@ -484,7 +471,7 @@ public class JakartaIdTest {
         private final String name;
         private final LocalDate birthdate;
 
-        public JpaIdSurrogateKeyPerson(
+        public JakartaIdSurrogateKeyPerson(
             UUID id,
             String socialSecurity,
             String name,
@@ -498,10 +485,10 @@ public class JakartaIdTest {
 
         @Override
         public boolean equals(Object obj) {
-            if (!(obj instanceof JpaIdSurrogateKeyPerson)) {
+            if (!(obj instanceof JakartaIdSurrogateKeyPerson)) {
                 return false;
             }
-            JpaIdSurrogateKeyPerson other = (JpaIdSurrogateKeyPerson) obj;
+            JakartaIdSurrogateKeyPerson other = (JakartaIdSurrogateKeyPerson) obj;
             return Objects.equals(id, other.id);
         }
 
@@ -511,7 +498,7 @@ public class JakartaIdTest {
         }
     }
 
-    static final class JpaIdSurrogateKeyPersonReorderedFields {
+    static final class JakartaIdSurrogateKeyPersonReorderedFields {
 
         private final String socialSecurity;
         private final String name;
@@ -520,7 +507,7 @@ public class JakartaIdTest {
         @jakarta.persistence.Id
         private final UUID id;
 
-        public JpaIdSurrogateKeyPersonReorderedFields(
+        public JakartaIdSurrogateKeyPersonReorderedFields(
             UUID id,
             String socialSecurity,
             String name,
@@ -534,10 +521,10 @@ public class JakartaIdTest {
 
         @Override
         public boolean equals(Object obj) {
-            if (!(obj instanceof JpaIdSurrogateKeyPersonReorderedFields)) {
+            if (!(obj instanceof JakartaIdSurrogateKeyPersonReorderedFields)) {
                 return false;
             }
-            JpaIdSurrogateKeyPersonReorderedFields other = (JpaIdSurrogateKeyPersonReorderedFields) obj;
+            JakartaIdSurrogateKeyPersonReorderedFields other = (JakartaIdSurrogateKeyPersonReorderedFields) obj;
             return Objects.equals(id, other.id);
         }
 
@@ -547,7 +534,7 @@ public class JakartaIdTest {
         }
     }
 
-    static final class JpaEmbeddedIdBusinessKeyPerson {
+    static final class JakartaEmbeddedIdBusinessKeyPerson {
 
         @jakarta.persistence.EmbeddedId
         private final UUID id;
@@ -556,7 +543,7 @@ public class JakartaIdTest {
         private final String name;
         private final LocalDate birthdate;
 
-        public JpaEmbeddedIdBusinessKeyPerson(
+        public JakartaEmbeddedIdBusinessKeyPerson(
             UUID id,
             String socialSecurity,
             String name,
@@ -570,10 +557,10 @@ public class JakartaIdTest {
 
         @Override
         public boolean equals(Object obj) {
-            if (!(obj instanceof JpaEmbeddedIdBusinessKeyPerson)) {
+            if (!(obj instanceof JakartaEmbeddedIdBusinessKeyPerson)) {
                 return false;
             }
-            JpaEmbeddedIdBusinessKeyPerson other = (JpaEmbeddedIdBusinessKeyPerson) obj;
+            JakartaEmbeddedIdBusinessKeyPerson other = (JakartaEmbeddedIdBusinessKeyPerson) obj;
             return (
                 Objects.equals(socialSecurity, other.socialSecurity) &&
                 Objects.equals(name, other.name) &&
@@ -587,7 +574,7 @@ public class JakartaIdTest {
         }
     }
 
-    static final class JpaEmbeddedIdSurrogateKeyPerson {
+    static final class JakartaEmbeddedIdSurrogateKeyPerson {
 
         @jakarta.persistence.EmbeddedId
         private final UUID id;
@@ -596,7 +583,7 @@ public class JakartaIdTest {
         private final String name;
         private final LocalDate birthdate;
 
-        public JpaEmbeddedIdSurrogateKeyPerson(
+        public JakartaEmbeddedIdSurrogateKeyPerson(
             UUID id,
             String socialSecurity,
             String name,
@@ -610,10 +597,10 @@ public class JakartaIdTest {
 
         @Override
         public boolean equals(Object obj) {
-            if (!(obj instanceof JpaEmbeddedIdSurrogateKeyPerson)) {
+            if (!(obj instanceof JakartaEmbeddedIdSurrogateKeyPerson)) {
                 return false;
             }
-            JpaEmbeddedIdSurrogateKeyPerson other = (JpaEmbeddedIdSurrogateKeyPerson) obj;
+            JakartaEmbeddedIdSurrogateKeyPerson other = (JakartaEmbeddedIdSurrogateKeyPerson) obj;
             return Objects.equals(id, other.id);
         }
 
@@ -661,44 +648,7 @@ public class JakartaIdTest {
         }
     }
 
-    static final class NaturalIdWithoutJpaIdBusinessKeyPerson {
-
-        private final UUID id;
-
-        @NaturalId
-        private final String socialSecurity;
-
-        private final String name;
-        private final LocalDate birthdate;
-
-        public NaturalIdWithoutJpaIdBusinessKeyPerson(
-            UUID id,
-            String socialSecurity,
-            String name,
-            LocalDate birthdate
-        ) {
-            this.id = id;
-            this.socialSecurity = socialSecurity;
-            this.name = name;
-            this.birthdate = birthdate;
-        }
-
-        @Override
-        public boolean equals(Object obj) {
-            if (!(obj instanceof NaturalIdWithoutJpaIdBusinessKeyPerson)) {
-                return false;
-            }
-            NaturalIdWithoutJpaIdBusinessKeyPerson other = (NaturalIdWithoutJpaIdBusinessKeyPerson) obj;
-            return Objects.equals(socialSecurity, other.socialSecurity);
-        }
-
-        @Override
-        public int hashCode() {
-            return Objects.hash(socialSecurity);
-        }
-    }
-
-    static final class JpaIdBusinessKeyPersonDoesntUseName {
+    static final class JakartaIdBusinessKeyPersonDoesntUseName {
 
         @jakarta.persistence.Id
         private final UUID id;
@@ -707,7 +657,7 @@ public class JakartaIdTest {
         private final String name;
         private final LocalDate birthdate;
 
-        public JpaIdBusinessKeyPersonDoesntUseName(
+        public JakartaIdBusinessKeyPersonDoesntUseName(
             UUID id,
             String socialSecurity,
             String name,
@@ -721,10 +671,10 @@ public class JakartaIdTest {
 
         @Override
         public boolean equals(Object obj) {
-            if (!(obj instanceof JpaIdBusinessKeyPersonDoesntUseName)) {
+            if (!(obj instanceof JakartaIdBusinessKeyPersonDoesntUseName)) {
                 return false;
             }
-            JpaIdBusinessKeyPersonDoesntUseName other = (JpaIdBusinessKeyPersonDoesntUseName) obj;
+            JakartaIdBusinessKeyPersonDoesntUseName other = (JakartaIdBusinessKeyPersonDoesntUseName) obj;
             return (
                 Objects.equals(socialSecurity, other.socialSecurity) &&
                 Objects.equals(birthdate, other.birthdate)
@@ -738,7 +688,7 @@ public class JakartaIdTest {
     }
 
     @jakarta.persistence.Entity
-    static final class JpaIdBusinessKeyPersonEntity {
+    static final class JakartaIdBusinessKeyPersonEntity {
 
         @jakarta.persistence.Id
         private UUID id;
@@ -749,10 +699,10 @@ public class JakartaIdTest {
 
         @Override
         public boolean equals(Object obj) {
-            if (!(obj instanceof JpaIdBusinessKeyPersonEntity)) {
+            if (!(obj instanceof JakartaIdBusinessKeyPersonEntity)) {
                 return false;
             }
-            JpaIdBusinessKeyPersonEntity other = (JpaIdBusinessKeyPersonEntity) obj;
+            JakartaIdBusinessKeyPersonEntity other = (JakartaIdBusinessKeyPersonEntity) obj;
             return (
                 Objects.equals(socialSecurity, other.socialSecurity) &&
                 Objects.equals(name, other.name) &&
@@ -790,46 +740,6 @@ public class JakartaIdTest {
         @Override
         public int hashCode() {
             return Objects.hash(socialSecurity);
-        }
-    }
-
-    static final class NonJpaIdBusinessKeyPerson {
-
-        @nl.jqno.equalsverifier.testhelpers.annotations.Id
-        private final UUID id;
-
-        private final String socialSecurity;
-        private final String name;
-        private final LocalDate birthdate;
-
-        public NonJpaIdBusinessKeyPerson(
-            UUID id,
-            String socialSecurity,
-            String name,
-            LocalDate birthdate
-        ) {
-            this.id = id;
-            this.socialSecurity = socialSecurity;
-            this.name = name;
-            this.birthdate = birthdate;
-        }
-
-        @Override
-        public boolean equals(Object obj) {
-            if (!(obj instanceof NonJpaIdBusinessKeyPerson)) {
-                return false;
-            }
-            NonJpaIdBusinessKeyPerson other = (NonJpaIdBusinessKeyPerson) obj;
-            return (
-                Objects.equals(socialSecurity, other.socialSecurity) &&
-                Objects.equals(name, other.name) &&
-                Objects.equals(birthdate, other.birthdate)
-            );
-        }
-
-        @Override
-        public int hashCode() {
-            return Objects.hash(socialSecurity, name, birthdate);
         }
     }
 
@@ -871,24 +781,24 @@ public class JakartaIdTest {
         }
     }
 
-    public static final class JpaIdVersionedEntity {
+    public static final class JakartaIdVersionedEntity {
 
         @jakarta.persistence.Id
         private final long id;
 
         private final String s;
 
-        public JpaIdVersionedEntity(long id, String s) {
+        public JakartaIdVersionedEntity(long id, String s) {
             this.id = id;
             this.s = s;
         }
 
         @Override
         public boolean equals(Object obj) {
-            if (!(obj instanceof JpaIdVersionedEntity)) {
+            if (!(obj instanceof JakartaIdVersionedEntity)) {
                 return false;
             }
-            JpaIdVersionedEntity other = (JpaIdVersionedEntity) obj;
+            JakartaIdVersionedEntity other = (JakartaIdVersionedEntity) obj;
             if (id == 0L && other.id == 0L) {
                 return Objects.equals(s, other.s);
             }

--- a/src/test/java/nl/jqno/equalsverifier/integration/extra_features/JakartaIdTest.java
+++ b/src/test/java/nl/jqno/equalsverifier/integration/extra_features/JakartaIdTest.java
@@ -1,0 +1,955 @@
+package nl.jqno.equalsverifier.integration.extra_features;
+
+import java.time.LocalDate;
+import java.util.Objects;
+import java.util.UUID;
+import nl.jqno.equalsverifier.EqualsVerifier;
+import nl.jqno.equalsverifier.Warning;
+import nl.jqno.equalsverifier.testhelpers.ExpectedException;
+import nl.jqno.equalsverifier.testhelpers.annotations.org.hibernate.annotations.NaturalId;
+import org.junit.jupiter.api.Test;
+
+@SuppressWarnings("unused")
+public class JakartaIdTest {
+
+    @Test
+    public void succeed_whenIdFieldIsNotUsed_givenIdIsAnnotatedWithId() {
+        EqualsVerifier.forClass(JpaIdBusinessKeyPerson.class).verify();
+        EqualsVerifier.forClass(JpaIdBusinessKeyPersonReorderedFields.class).verify();
+    }
+
+    @Test
+    public void succeed_whenOnlyIdFieldIsUsed_givenIdIsAnnotatedWithIdAndSurrogateKeyWarningIsSuppressed() {
+        EqualsVerifier
+            .forClass(JpaIdSurrogateKeyPerson.class)
+            .suppress(Warning.SURROGATE_KEY)
+            .verify();
+        EqualsVerifier
+            .forClass(JpaIdSurrogateKeyPersonReorderedFields.class)
+            .suppress(Warning.SURROGATE_KEY)
+            .verify();
+    }
+
+    @Test
+    public void fail_whenIdFieldIsNotUsed_givenIdIsAnnotatedWithIdButIdAnnotationIsIgnored() {
+        ExpectedException
+            .when(() ->
+                EqualsVerifier
+                    .forClass(JpaIdBusinessKeyPerson.class)
+                    .withIgnoredAnnotations(jakarta.persistence.Id.class)
+                    .verify()
+            )
+            .assertFailure()
+            .assertMessageContains("Significant fields", "equals does not use id");
+    }
+
+    @Test
+    public void fail_whenOnlyIdFieldIsUsed_givenIdIsAnnotatedWithId() {
+        ExpectedException
+            .when(() -> EqualsVerifier.forClass(JpaIdSurrogateKeyPerson.class).verify())
+            .assertFailure()
+            .assertMessageContains(
+                "Significant fields",
+                "id is marked @Id",
+                "equals should not use it",
+                "Suppress Warning.SURROGATE_KEY if"
+            );
+    }
+
+    @Test
+    public void fail_whenOnlyIdFieldIsUsed_givenIdIsAnnotatedWithId2() {
+        ExpectedException
+            .when(() ->
+                EqualsVerifier.forClass(JpaIdSurrogateKeyPersonReorderedFields.class).verify()
+            )
+            .assertFailure()
+            .assertMessageContains(
+                "Significant fields",
+                "equals does not use socialSecurity",
+                "Suppress Warning.SURROGATE_KEY if"
+            );
+    }
+
+    @Test
+    public void fail_whenIdFieldIsNotUsed_givenIdIsAnnotatedWithIdAndSurrogateKeyWarningIsSuppressed() {
+        ExpectedException
+            .when(() ->
+                EqualsVerifier
+                    .forClass(JpaIdBusinessKeyPerson.class)
+                    .suppress(Warning.SURROGATE_KEY)
+                    .verify()
+            )
+            .assertFailure()
+            .assertMessageContains(
+                "Significant fields",
+                "id is marked @Id",
+                "Warning.SURROGATE_KEY",
+                "equals does not use"
+            );
+    }
+
+    @Test
+    public void fail_whenIdFieldIsNotUsed_givenIdIsAnnotatedWithIdAndSurrogateKeyWarningIsSuppressed2() {
+        ExpectedException
+            .when(() ->
+                EqualsVerifier
+                    .forClass(JpaIdBusinessKeyPersonReorderedFields.class)
+                    .suppress(Warning.SURROGATE_KEY)
+                    .verify()
+            )
+            .assertFailure()
+            .assertMessageContains(
+                "Significant fields",
+                "equals should not use socialSecurity",
+                "Warning.SURROGATE_KEY is suppressed and it is not marked as @Id",
+                "but it does"
+            );
+    }
+
+    @Test
+    public void succeed_whenEmbeddedIdIsUsedCorrectly() {
+        EqualsVerifier.forClass(JpaEmbeddedIdBusinessKeyPerson.class).verify();
+        EqualsVerifier
+            .forClass(JpaEmbeddedIdSurrogateKeyPerson.class)
+            .suppress(Warning.SURROGATE_KEY)
+            .verify();
+    }
+
+    @Test
+    public void fail_whenOnlyEmbeddedIdFieldIsUsed_givenIdIsAnnotatedWithEmbeddedId() {
+        ExpectedException
+            .when(() -> EqualsVerifier.forClass(JpaEmbeddedIdSurrogateKeyPerson.class).verify())
+            .assertFailure()
+            .assertMessageContains(
+                "Significant fields",
+                "id is marked @Id or @EmbeddedId",
+                "equals should not use it",
+                "Suppress Warning.SURROGATE_KEY if"
+            );
+    }
+
+    @Test
+    public void fail_whenIdFieldIsNotUsed_givenIdIsAnnotatedWithEmbeddedIdAndSurrogateKeyWarningIsSuppressed() {
+        ExpectedException
+            .when(() ->
+                EqualsVerifier
+                    .forClass(JpaEmbeddedIdBusinessKeyPerson.class)
+                    .suppress(Warning.SURROGATE_KEY)
+                    .verify()
+            )
+            .assertFailure()
+            .assertMessageContains(
+                "Significant fields",
+                "id is marked @Id or @EmbeddedId",
+                "Warning.SURROGATE_KEY",
+                "equals does not use"
+            );
+    }
+
+    @Test
+    public void fail_whenEmbeddedIdFieldIsTheOnlyFieldUsed() {
+        ExpectedException
+            .when(() ->
+                EqualsVerifier
+                    .forClass(JpaEmbeddedIdBusinessKeyPerson.class)
+                    .withOnlyTheseFields("id")
+                    .verify()
+            )
+            .assertFailure()
+            .assertMessageContains(
+                "Precondition: you can't use withOnlyTheseFields on a field marked @Id or @EmbeddedId.",
+                "Suppress Warning.SURROGATE_KEY if"
+            );
+    }
+
+    @Test
+    public void succeed_whenOnlySocialSecurityIsUsed_givenSocialSecurityIsAnnotatedWithNaturalId() {
+        EqualsVerifier.forClass(NaturalIdBusinessKeyPerson.class).verify();
+    }
+
+    @Test
+    public void succeed_whenOnlySocialSecurityIsUsed_givenSocialSecurityIsAnnotatedWithNaturalIdAndNothingIsAnnotatedWithJpaId() {
+        EqualsVerifier.forClass(NaturalIdWithoutJpaIdBusinessKeyPerson.class).verify();
+    }
+
+    @Test
+    public void fail_whenOnlySocialSecurityIsUsed_givenSocialSecurityIsAnnotatedWithNaturalIdButIdAnnotationIsIgnored() {
+        ExpectedException
+            .when(() ->
+                EqualsVerifier
+                    .forClass(NaturalIdBusinessKeyPerson.class)
+                    .withIgnoredAnnotations(NaturalId.class)
+                    .verify()
+            )
+            .assertFailure()
+            .assertMessageContains("Significant fields", "equals does not use name");
+    }
+
+    @Test
+    public void succeed_whenIdAndNameFieldsAreNotUsed_givenNameIsIgnored() {
+        EqualsVerifier
+            .forClass(JpaIdBusinessKeyPersonDoesntUseName.class)
+            .withIgnoredFields("name")
+            .verify();
+    }
+
+    @Test
+    public void succeed_whenIdAndNameFieldsAreNotUsed_givenSocialSecurityAndBirthdateAreOnlyUsed() {
+        EqualsVerifier
+            .forClass(JpaIdBusinessKeyPersonDoesntUseName.class)
+            .withOnlyTheseFields("socialSecurity", "birthdate")
+            .verify();
+    }
+
+    @Test
+    public void succeed_whenIdIsPartOfAProperJpaEntity() {
+        EqualsVerifier.forClass(JpaIdBusinessKeyPersonEntity.class).verify();
+    }
+
+    @Test
+    public void succeed_whenNaturalIdIsPartOfAProperJpaEntity() {
+        EqualsVerifier.forClass(NaturalIdBusinessKeyPersonEntity.class).verify();
+    }
+
+    @Test
+    public void succeed_whenEqualsBehavesLikeVersionedEntity_givenIdIsMarkedWithIdAndWarningVersionedEntityIsSuppressed() {
+        EqualsVerifier
+            .forClass(JpaIdVersionedEntity.class)
+            .suppress(Warning.IDENTICAL_COPY_FOR_VERSIONED_ENTITY)
+            .verify();
+    }
+
+    @Test
+    public void succeed_whenMethodsAreAnnotatedInsteadOfFields() {
+        EqualsVerifier.forClass(MethodAnnotatedBusinessKeyPerson.class).verify();
+    }
+
+    @Test
+    public void fail_whenIdFieldIsTheOnlyFieldUsed() {
+        ExpectedException
+            .when(() ->
+                EqualsVerifier
+                    .forClass(JpaIdBusinessKeyPerson.class)
+                    .withOnlyTheseFields("id")
+                    .verify()
+            )
+            .assertFailure()
+            .assertMessageContains(
+                "Precondition: you can't use withOnlyTheseFields on a field marked @Id or @EmbeddedId.",
+                "Suppress Warning.SURROGATE_KEY if"
+            );
+    }
+
+    @Test
+    public void fail_whenOnlySocialSecurityIsUsed_givenSocialSecurityIsAnnotatedWithNaturalIdButSurrogateKeyWarningIsSuppressed() {
+        ExpectedException
+            .when(() ->
+                EqualsVerifier
+                    .forClass(NaturalIdBusinessKeyPerson.class)
+                    .suppress(Warning.SURROGATE_KEY)
+                    .verify()
+            )
+            .assertFailure()
+            .assertMessageContains(
+                "Precondition: you can't suppress Warning.SURROGATE_KEY when fields are marked @NaturalId."
+            );
+    }
+
+    @Test
+    public void fail_whenWithOnlyTheseFieldsIsUsed_givenWarningSurrogateKeyIsSuppressed() {
+        ExpectedException
+            .when(() ->
+                EqualsVerifier
+                    .forClass(JpaIdSurrogateKeyPerson.class)
+                    .withOnlyTheseFields("socialSecurity")
+                    .suppress(Warning.SURROGATE_KEY)
+            )
+            .assertThrows(IllegalStateException.class)
+            .assertMessageContains(
+                "Precondition",
+                "you can't use withOnlyTheseFields when Warning.SURROGATE_KEY is suppressed."
+            );
+    }
+
+    @Test
+    public void fail_whenWithOnlyTheseFieldsIsUsed_givenWarningSurrogateKeyIsSuppressedInReverse() {
+        ExpectedException
+            .when(() ->
+                EqualsVerifier
+                    .forClass(JpaIdSurrogateKeyPerson.class)
+                    .suppress(Warning.SURROGATE_KEY)
+                    .withOnlyTheseFields("socialSecurity")
+            )
+            .assertThrows(IllegalStateException.class)
+            .assertMessageContains(
+                "Precondition",
+                "you can't use withOnlyTheseFields when Warning.SURROGATE_KEY is suppressed."
+            );
+    }
+
+    @Test
+    public void fail_whenFieldsAreIgnored_givenWarningSurrogateKeyIsSuppressed() {
+        ExpectedException
+            .when(() ->
+                EqualsVerifier
+                    .forClass(JpaIdSurrogateKeyPerson.class)
+                    .withIgnoredFields("socialSecurity")
+                    .suppress(Warning.SURROGATE_KEY)
+            )
+            .assertThrows(IllegalStateException.class)
+            .assertMessageContains(
+                "Precondition: you can't use withIgnoredFields when Warning.SURROGATE_KEY is suppressed."
+            );
+    }
+
+    @Test
+    public void fail_whenFieldsAreIgnored_givenWarningSurrogateKeyIsSuppressedInReverse() {
+        ExpectedException
+            .when(() ->
+                EqualsVerifier
+                    .forClass(JpaIdSurrogateKeyPerson.class)
+                    .suppress(Warning.SURROGATE_KEY)
+                    .withIgnoredFields("socialSecurity")
+            )
+            .assertThrows(IllegalStateException.class)
+            .assertMessageContains(
+                "Precondition: you can't use withIgnoredFields when Warning.SURROGATE_KEY is suppressed."
+            );
+    }
+
+    @Test
+    public void fail_whenWithOnlyTheseFieldsIsUsed_givenFieldsAreMarkedWithNaturalId() {
+        ExpectedException
+            .when(() ->
+                EqualsVerifier
+                    .forClass(NaturalIdBusinessKeyPerson.class)
+                    .withOnlyTheseFields("socialSecurity")
+                    .verify()
+            )
+            .assertFailure()
+            .assertMessageContains(
+                "Precondition: you can't use withOnlyTheseFields when fields are marked with @NaturalId."
+            );
+    }
+
+    @Test
+    public void fail_whenFieldsAreIgnored_givenFieldsAreMarkedWithNaturalId() {
+        ExpectedException
+            .when(() ->
+                EqualsVerifier
+                    .forClass(NaturalIdBusinessKeyPerson.class)
+                    .withIgnoredFields("socialSecurity")
+                    .verify()
+            )
+            .assertFailure()
+            .assertMessageContains(
+                "Precondition: you can't use withIgnoredFields when fields are marked with @NaturalId."
+            );
+    }
+
+    @Test
+    public void fail_whenWarningVersionedEntityIsSuppressed_givenAFieldIsAnnotatedWithNaturalId() {
+        ExpectedException
+            .when(() ->
+                EqualsVerifier
+                    .forClass(NaturalIdBusinessKeyPerson.class)
+                    .suppress(Warning.IDENTICAL_COPY_FOR_VERSIONED_ENTITY)
+                    .verify()
+            )
+            .assertFailure()
+            .assertMessageContains(
+                "Precondition: you can't suppress Warning.IDENTICAL_COPY_FOR_VERSIONED_ENTITY when fields are marked with @NaturalId."
+            );
+    }
+
+    @Test
+    public void fail_whenWarningVersionedEntityIsSuppressed_givenWarningSurrogateKeyIsAlsoSuppressed() {
+        ExpectedException
+            .when(() ->
+                EqualsVerifier
+                    .forClass(JpaIdBusinessKeyPerson.class)
+                    .suppress(Warning.SURROGATE_KEY, Warning.IDENTICAL_COPY_FOR_VERSIONED_ENTITY)
+            )
+            .assertThrows(IllegalStateException.class)
+            .assertMessageContains(
+                "Precondition",
+                "you can't suppress Warning.IDENTICAL_COPY_FOR_VERSIONED_ENTITY when Warning.SURROGATE_KEY is also suppressed."
+            );
+    }
+
+    @Test
+    public void fail_whenAnIdAnnotationFromAnotherPackageIsUsed() {
+        ExpectedException
+            .when(() -> EqualsVerifier.forClass(NonJpaIdBusinessKeyPerson.class).verify())
+            .assertFailure()
+            .assertMessageContains("Significant fields");
+    }
+
+    @Test
+    public void fail_whenANaturalIdAnnotationFromAnotherPackageIsUsed() {
+        ExpectedException
+            .when(() ->
+                EqualsVerifier.forClass(NonHibernateNaturalIdBusinessKeyPerson.class).verify()
+            )
+            .assertFailure()
+            .assertMessageContains("Significant fields");
+    }
+
+    static final class JpaIdBusinessKeyPerson {
+
+        @jakarta.persistence.Id
+        private final UUID id;
+
+        private final String socialSecurity;
+        private final String name;
+        private final LocalDate birthdate;
+
+        public JpaIdBusinessKeyPerson(
+            UUID id,
+            String socialSecurity,
+            String name,
+            LocalDate birthdate
+        ) {
+            this.id = id;
+            this.socialSecurity = socialSecurity;
+            this.name = name;
+            this.birthdate = birthdate;
+        }
+
+        @Override
+        public boolean equals(Object obj) {
+            if (!(obj instanceof JpaIdBusinessKeyPerson)) {
+                return false;
+            }
+            JpaIdBusinessKeyPerson other = (JpaIdBusinessKeyPerson) obj;
+            return (
+                Objects.equals(socialSecurity, other.socialSecurity) &&
+                Objects.equals(name, other.name) &&
+                Objects.equals(birthdate, other.birthdate)
+            );
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(socialSecurity, name, birthdate);
+        }
+    }
+
+    static final class JpaIdBusinessKeyPersonReorderedFields {
+
+        private final String socialSecurity;
+        private final String name;
+        private final LocalDate birthdate;
+
+        @jakarta.persistence.Id
+        private final UUID id;
+
+        public JpaIdBusinessKeyPersonReorderedFields(
+            UUID id,
+            String socialSecurity,
+            String name,
+            LocalDate birthdate
+        ) {
+            this.id = id;
+            this.socialSecurity = socialSecurity;
+            this.name = name;
+            this.birthdate = birthdate;
+        }
+
+        @Override
+        public boolean equals(Object obj) {
+            if (!(obj instanceof JpaIdBusinessKeyPersonReorderedFields)) {
+                return false;
+            }
+            JpaIdBusinessKeyPersonReorderedFields other = (JpaIdBusinessKeyPersonReorderedFields) obj;
+            return (
+                Objects.equals(socialSecurity, other.socialSecurity) &&
+                Objects.equals(name, other.name) &&
+                Objects.equals(birthdate, other.birthdate)
+            );
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(socialSecurity, name, birthdate);
+        }
+    }
+
+    static final class JpaIdSurrogateKeyPerson {
+
+        @jakarta.persistence.Id
+        private final UUID id;
+
+        private final String socialSecurity;
+        private final String name;
+        private final LocalDate birthdate;
+
+        public JpaIdSurrogateKeyPerson(
+            UUID id,
+            String socialSecurity,
+            String name,
+            LocalDate birthdate
+        ) {
+            this.id = id;
+            this.socialSecurity = socialSecurity;
+            this.name = name;
+            this.birthdate = birthdate;
+        }
+
+        @Override
+        public boolean equals(Object obj) {
+            if (!(obj instanceof JpaIdSurrogateKeyPerson)) {
+                return false;
+            }
+            JpaIdSurrogateKeyPerson other = (JpaIdSurrogateKeyPerson) obj;
+            return Objects.equals(id, other.id);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(id);
+        }
+    }
+
+    static final class JpaIdSurrogateKeyPersonReorderedFields {
+
+        private final String socialSecurity;
+        private final String name;
+        private final LocalDate birthdate;
+
+        @jakarta.persistence.Id
+        private final UUID id;
+
+        public JpaIdSurrogateKeyPersonReorderedFields(
+            UUID id,
+            String socialSecurity,
+            String name,
+            LocalDate birthdate
+        ) {
+            this.id = id;
+            this.socialSecurity = socialSecurity;
+            this.name = name;
+            this.birthdate = birthdate;
+        }
+
+        @Override
+        public boolean equals(Object obj) {
+            if (!(obj instanceof JpaIdSurrogateKeyPersonReorderedFields)) {
+                return false;
+            }
+            JpaIdSurrogateKeyPersonReorderedFields other = (JpaIdSurrogateKeyPersonReorderedFields) obj;
+            return Objects.equals(id, other.id);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(id);
+        }
+    }
+
+    static final class JpaEmbeddedIdBusinessKeyPerson {
+
+        @jakarta.persistence.EmbeddedId
+        private final UUID id;
+
+        private final String socialSecurity;
+        private final String name;
+        private final LocalDate birthdate;
+
+        public JpaEmbeddedIdBusinessKeyPerson(
+            UUID id,
+            String socialSecurity,
+            String name,
+            LocalDate birthdate
+        ) {
+            this.id = id;
+            this.socialSecurity = socialSecurity;
+            this.name = name;
+            this.birthdate = birthdate;
+        }
+
+        @Override
+        public boolean equals(Object obj) {
+            if (!(obj instanceof JpaEmbeddedIdBusinessKeyPerson)) {
+                return false;
+            }
+            JpaEmbeddedIdBusinessKeyPerson other = (JpaEmbeddedIdBusinessKeyPerson) obj;
+            return (
+                Objects.equals(socialSecurity, other.socialSecurity) &&
+                Objects.equals(name, other.name) &&
+                Objects.equals(birthdate, other.birthdate)
+            );
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(socialSecurity, name, birthdate);
+        }
+    }
+
+    static final class JpaEmbeddedIdSurrogateKeyPerson {
+
+        @jakarta.persistence.EmbeddedId
+        private final UUID id;
+
+        private final String socialSecurity;
+        private final String name;
+        private final LocalDate birthdate;
+
+        public JpaEmbeddedIdSurrogateKeyPerson(
+            UUID id,
+            String socialSecurity,
+            String name,
+            LocalDate birthdate
+        ) {
+            this.id = id;
+            this.socialSecurity = socialSecurity;
+            this.name = name;
+            this.birthdate = birthdate;
+        }
+
+        @Override
+        public boolean equals(Object obj) {
+            if (!(obj instanceof JpaEmbeddedIdSurrogateKeyPerson)) {
+                return false;
+            }
+            JpaEmbeddedIdSurrogateKeyPerson other = (JpaEmbeddedIdSurrogateKeyPerson) obj;
+            return Objects.equals(id, other.id);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(id);
+        }
+    }
+
+    static final class NaturalIdBusinessKeyPerson {
+
+        @jakarta.persistence.Id
+        private final UUID id;
+
+        @NaturalId
+        private final String socialSecurity;
+
+        private final String name;
+        private final LocalDate birthdate;
+
+        public NaturalIdBusinessKeyPerson(
+            UUID id,
+            String socialSecurity,
+            String name,
+            LocalDate birthdate
+        ) {
+            this.id = id;
+            this.socialSecurity = socialSecurity;
+            this.name = name;
+            this.birthdate = birthdate;
+        }
+
+        @Override
+        public boolean equals(Object obj) {
+            if (!(obj instanceof NaturalIdBusinessKeyPerson)) {
+                return false;
+            }
+            NaturalIdBusinessKeyPerson other = (NaturalIdBusinessKeyPerson) obj;
+            return Objects.equals(socialSecurity, other.socialSecurity);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(socialSecurity);
+        }
+    }
+
+    static final class NaturalIdWithoutJpaIdBusinessKeyPerson {
+
+        private final UUID id;
+
+        @NaturalId
+        private final String socialSecurity;
+
+        private final String name;
+        private final LocalDate birthdate;
+
+        public NaturalIdWithoutJpaIdBusinessKeyPerson(
+            UUID id,
+            String socialSecurity,
+            String name,
+            LocalDate birthdate
+        ) {
+            this.id = id;
+            this.socialSecurity = socialSecurity;
+            this.name = name;
+            this.birthdate = birthdate;
+        }
+
+        @Override
+        public boolean equals(Object obj) {
+            if (!(obj instanceof NaturalIdWithoutJpaIdBusinessKeyPerson)) {
+                return false;
+            }
+            NaturalIdWithoutJpaIdBusinessKeyPerson other = (NaturalIdWithoutJpaIdBusinessKeyPerson) obj;
+            return Objects.equals(socialSecurity, other.socialSecurity);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(socialSecurity);
+        }
+    }
+
+    static final class JpaIdBusinessKeyPersonDoesntUseName {
+
+        @jakarta.persistence.Id
+        private final UUID id;
+
+        private final String socialSecurity;
+        private final String name;
+        private final LocalDate birthdate;
+
+        public JpaIdBusinessKeyPersonDoesntUseName(
+            UUID id,
+            String socialSecurity,
+            String name,
+            LocalDate birthdate
+        ) {
+            this.id = id;
+            this.socialSecurity = socialSecurity;
+            this.name = name;
+            this.birthdate = birthdate;
+        }
+
+        @Override
+        public boolean equals(Object obj) {
+            if (!(obj instanceof JpaIdBusinessKeyPersonDoesntUseName)) {
+                return false;
+            }
+            JpaIdBusinessKeyPersonDoesntUseName other = (JpaIdBusinessKeyPersonDoesntUseName) obj;
+            return (
+                Objects.equals(socialSecurity, other.socialSecurity) &&
+                Objects.equals(birthdate, other.birthdate)
+            );
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(socialSecurity, birthdate);
+        }
+    }
+
+    @jakarta.persistence.Entity
+    static final class JpaIdBusinessKeyPersonEntity {
+
+        @jakarta.persistence.Id
+        private UUID id;
+
+        private String socialSecurity;
+        private String name;
+        private LocalDate birthdate;
+
+        @Override
+        public boolean equals(Object obj) {
+            if (!(obj instanceof JpaIdBusinessKeyPersonEntity)) {
+                return false;
+            }
+            JpaIdBusinessKeyPersonEntity other = (JpaIdBusinessKeyPersonEntity) obj;
+            return (
+                Objects.equals(socialSecurity, other.socialSecurity) &&
+                Objects.equals(name, other.name) &&
+                Objects.equals(birthdate, other.birthdate)
+            );
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(socialSecurity, name, birthdate);
+        }
+    }
+
+    @jakarta.persistence.Entity
+    static final class NaturalIdBusinessKeyPersonEntity {
+
+        @jakarta.persistence.Id
+        private UUID id;
+
+        @NaturalId
+        private String socialSecurity;
+
+        private String name;
+        private LocalDate birthdate;
+
+        @Override
+        public boolean equals(Object obj) {
+            if (!(obj instanceof NaturalIdBusinessKeyPersonEntity)) {
+                return false;
+            }
+            NaturalIdBusinessKeyPersonEntity other = (NaturalIdBusinessKeyPersonEntity) obj;
+            return Objects.equals(socialSecurity, other.socialSecurity);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(socialSecurity);
+        }
+    }
+
+    static final class NonJpaIdBusinessKeyPerson {
+
+        @nl.jqno.equalsverifier.testhelpers.annotations.Id
+        private final UUID id;
+
+        private final String socialSecurity;
+        private final String name;
+        private final LocalDate birthdate;
+
+        public NonJpaIdBusinessKeyPerson(
+            UUID id,
+            String socialSecurity,
+            String name,
+            LocalDate birthdate
+        ) {
+            this.id = id;
+            this.socialSecurity = socialSecurity;
+            this.name = name;
+            this.birthdate = birthdate;
+        }
+
+        @Override
+        public boolean equals(Object obj) {
+            if (!(obj instanceof NonJpaIdBusinessKeyPerson)) {
+                return false;
+            }
+            NonJpaIdBusinessKeyPerson other = (NonJpaIdBusinessKeyPerson) obj;
+            return (
+                Objects.equals(socialSecurity, other.socialSecurity) &&
+                Objects.equals(name, other.name) &&
+                Objects.equals(birthdate, other.birthdate)
+            );
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(socialSecurity, name, birthdate);
+        }
+    }
+
+    static final class NonHibernateNaturalIdBusinessKeyPerson {
+
+        @jakarta.persistence.Id
+        private final UUID id;
+
+        @nl.jqno.equalsverifier.testhelpers.annotations.NaturalId
+        private final String socialSecurity;
+
+        private final String name;
+        private final LocalDate birthdate;
+
+        public NonHibernateNaturalIdBusinessKeyPerson(
+            UUID id,
+            String socialSecurity,
+            String name,
+            LocalDate birthdate
+        ) {
+            this.id = id;
+            this.socialSecurity = socialSecurity;
+            this.name = name;
+            this.birthdate = birthdate;
+        }
+
+        @Override
+        public boolean equals(Object obj) {
+            if (!(obj instanceof NonHibernateNaturalIdBusinessKeyPerson)) {
+                return false;
+            }
+            NonHibernateNaturalIdBusinessKeyPerson other = (NonHibernateNaturalIdBusinessKeyPerson) obj;
+            return Objects.equals(socialSecurity, other.socialSecurity);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(socialSecurity);
+        }
+    }
+
+    public static final class JpaIdVersionedEntity {
+
+        @jakarta.persistence.Id
+        private final long id;
+
+        private final String s;
+
+        public JpaIdVersionedEntity(long id, String s) {
+            this.id = id;
+            this.s = s;
+        }
+
+        @Override
+        public boolean equals(Object obj) {
+            if (!(obj instanceof JpaIdVersionedEntity)) {
+                return false;
+            }
+            JpaIdVersionedEntity other = (JpaIdVersionedEntity) obj;
+            if (id == 0L && other.id == 0L) {
+                return Objects.equals(s, other.s);
+            }
+            return id == other.id;
+        }
+
+        @Override
+        public int hashCode() {
+            return Float.floatToIntBits(id);
+        }
+    }
+
+    static final class MethodAnnotatedBusinessKeyPerson {
+
+        private final UUID id;
+        private final String socialSecurity;
+        private final String name;
+        private final LocalDate birthdate;
+
+        public MethodAnnotatedBusinessKeyPerson(
+            UUID id,
+            String socialSecurity,
+            String name,
+            LocalDate birthdate
+        ) {
+            this.id = id;
+            this.socialSecurity = socialSecurity;
+            this.name = name;
+            this.birthdate = birthdate;
+        }
+
+        @jakarta.persistence.Id
+        public UUID getId() {
+            return id;
+        }
+
+        @NaturalId
+        public String getSocialSecurity() {
+            return socialSecurity;
+        }
+
+        public String getName() {
+            return name;
+        }
+
+        public LocalDate getBirthdate() {
+            return birthdate;
+        }
+
+        @Override
+        public boolean equals(Object obj) {
+            if (!(obj instanceof MethodAnnotatedBusinessKeyPerson)) {
+                return false;
+            }
+            MethodAnnotatedBusinessKeyPerson other = (MethodAnnotatedBusinessKeyPerson) obj;
+            return Objects.equals(socialSecurity, other.socialSecurity);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(socialSecurity);
+        }
+    }
+}


### PR DESCRIPTION
# What problem does this pull request solve?
Jakarta persistence's annotations were not supported.

# Please provide any additional information below.
Jakarta persistence's annotations only rename "javax.persistence" to "jakarta.persistence" afaIk.

# NOTE
* Please run `mvn spotless:apply` to format the code before opening a PR. Otherwise, GitHub Actions will complain at you 😉. Unfortunately, you will need to have Node installed to do so.
* Mutation tests will be run by [PITest](https://pitest.org/) after opening the PR. It will post comments in the PR for each issue found. Please take a look at them, but if the comments don't make sense, please don't worry about them.

