### PR TITLE
Fix issue when the project path contains whitespaces

### DIFF
--- a/equalsverifier-core/src/main/java/nl/jqno/equalsverifier/internal/reflection/PackageScanner.java
+++ b/equalsverifier-core/src/main/java/nl/jqno/equalsverifier/internal/reflection/PackageScanner.java
@@ -3,6 +3,7 @@ package nl.jqno.equalsverifier.internal.reflection;
 import static nl.jqno.equalsverifier.internal.util.Rethrow.rethrow;
 
 import java.io.File;
+import java.net.URL;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
@@ -36,10 +37,14 @@ public final class PackageScanner {
                 Collections
                     .list(cl.getResources(path))
                     .stream()
-                    .map(r -> new File(r.getFile()))
+                    .map(r -> new File(getResourcePath(r)))
                     .collect(Collectors.toList()),
             e -> "Could not scan package " + packageName
         );
+    }
+
+    private static String getResourcePath(URL r) {
+        return rethrow(() -> r.toURI().getPath(), e -> "Could not resolve resource path: " + e.getMessage());
     }
 
     private static List<Class<?>> getClassesInDir(


### PR DESCRIPTION
# What problem does this pull request solve?
If we have a project on the computer in a directory that contains spaces (example: _C:\Documents and Settings\Projects\MyProject_), the library resolves the path of the directories by calling the method `URL.getFile()`.
The paths contain `%20` characters instead of spaces.
When the library checks if the directory exists (`File.exists()`), then it does not find the directory.

The solution is to replace `URL.getFile()` by `URL.toURI().getPath()`.

References : 
https://community.oracle.com/tech/developers/discussion/2058345/url-getfile-outputs-20-as-space
https://stackoverflow.com/questions/3263560/sysloader-getresource-problem-in-java

# NOTE
* Please run `mvn spotless:apply` to format the code before opening a PR. Otherwise, GitHub Actions will complain at you 😉. Unfortunately, you will need to have Node installed to do so.
* Mutation tests will be run by [PITest](https://pitest.org/) after opening the PR. It will post comments in the PR for each issue found. Please take a look at them, but if the comments don't make sense, please don't worry about them.

