### PR TITLE
minor: make private class final with default constructor

### DIFF
--- a/equalsverifier-core/src/test/java/nl/jqno/equalsverifier/integration/operational/OutputTest.java
+++ b/equalsverifier-core/src/test/java/nl/jqno/equalsverifier/integration/operational/OutputTest.java
@@ -90,7 +90,7 @@ public class OutputTest {
             .assertNotCause(StackOverflowError.class);
     }
 
-    private static class AssertionExceptionWithCauseThrower {
+    private static final class AssertionExceptionWithCauseThrower {
 
         @Override
         public boolean equals(Object obj) {
@@ -99,7 +99,7 @@ public class OutputTest {
         }
     }
 
-    private static class UnsupportedOperationExceptionWithMessageThrower {
+    private static final class UnsupportedOperationExceptionWithMessageThrower {
 
         @Override
         public boolean equals(Object obj) {
@@ -107,7 +107,7 @@ public class OutputTest {
         }
     }
 
-    private static class IllegalStateExceptionThrower {
+    private static final class IllegalStateExceptionThrower {
 
         @Override
         public boolean equals(Object obj) {

--- a/equalsverifier-core/src/test/java/nl/jqno/equalsverifier/internal/prefabvalues/PrefabValuesTest.java
+++ b/equalsverifier-core/src/test/java/nl/jqno/equalsverifier/internal/prefabvalues/PrefabValuesTest.java
@@ -289,7 +289,7 @@ public class PrefabValuesTest {
     }
 
     @SuppressWarnings("rawtypes")
-    private static class ListTestFactory implements PrefabValueFactory<List> {
+    private static final class ListTestFactory implements PrefabValueFactory<List> {
 
         @Override
         @SuppressWarnings("unchecked")
@@ -313,7 +313,7 @@ public class PrefabValuesTest {
         }
     }
 
-    private static class StaticContainer {
+    private static final class StaticContainer {
 
         static int staticInt = 2;
 

--- a/equalsverifier-core/src/test/java/nl/jqno/equalsverifier/internal/reflection/annotations/AnnotationCacheBuilderTest.java
+++ b/equalsverifier-core/src/test/java/nl/jqno/equalsverifier/internal/reflection/annotations/AnnotationCacheBuilderTest.java
@@ -452,7 +452,7 @@ public class AnnotationCacheBuilderTest {
         assertFalse(cache.hasFieldAnnotation(type, fieldName, annotation));
     }
 
-    private static class AnnotationWithClassValuesAnnotation implements Annotation {
+    private static final class AnnotationWithClassValuesAnnotation implements Annotation {
 
         private AnnotationProperties properties;
 
@@ -483,5 +483,5 @@ public class AnnotationCacheBuilderTest {
         annotations = { Nonnull.class, NotNull.class },
         elementType = ElementType.FIELD
     )
-    private static class AnnotationWithValuesContainer {}
+    private static final class AnnotationWithValuesContainer {}
 }


### PR DESCRIPTION
minor: make private class final with default constructor

This is part of https://github.com/checkstyle/checkstyle/pull/12737

According to the https://docs.oracle.com/javase/specs/jls/se17/html/jls-8.html#jls-8.8.9 The default constructor has the same access modifier as the class.
and according to the check https://checkstyle.org/config_design.html#FinalClass a class that has only private constructors and has no descendant classes is declared as final.