### PR TITLE
fix line-endings conflict between prettier and git

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,6 @@
+* text=auto eol=lf
+
+# make sure that script files are always in the correct format, no matter the OS.
+# i.e. Windows needs batch files to have CRLF, but shell scripts always need to be LF, which is especially important for WSL contexts.
+*.sh           text eol=lf
+*.bat          text eol=crlf

--- a/.prettierrc.yml
+++ b/.prettierrc.yml
@@ -1,3 +1,4 @@
 tabWidth: 4
 printWidth: 100
 trailingComma: "none"
+endOfLine: "lf"


### PR DESCRIPTION
The git attribute normalizes line endings for git checkout and pushing, depending on the user's OS.  
See https://git-scm.com/docs/gitattributes#_end_of_line_conversion

The prettier config does the same, so the working directory is not polluted with pseudo git-changes 
when running Prettier.

This is checked on a Windows machine.   
Please double check on a Unix or Mac.