### PR TITLE
Apply AssertJ best practices

### DIFF
--- a/equalsverifier-16/src/test/java/nl/jqno/equalsverifier/internal/instantiation/vintage/reflection/RecordObjectAccessorCopyingTest.java
+++ b/equalsverifier-16/src/test/java/nl/jqno/equalsverifier/internal/instantiation/vintage/reflection/RecordObjectAccessorCopyingTest.java
@@ -18,8 +18,7 @@ class RecordObjectAccessorCopyingTest {
         Object original = instantiate(SimpleRecord.class);
         Object copy = copyOf(original);
 
-        assertThat(copy).isNotSameAs(original);
-        assertThat(copy).isEqualTo(original);
+        assertThat(copy).isNotSameAs(original).isEqualTo(original);
     }
 
     @Test

--- a/equalsverifier-core/src/test/java/nl/jqno/equalsverifier/integration/operational/MultipleTypeEqualsVerifierTest.java
+++ b/equalsverifier-core/src/test/java/nl/jqno/equalsverifier/integration/operational/MultipleTypeEqualsVerifierTest.java
@@ -241,7 +241,7 @@ class MultipleTypeEqualsVerifierTest {
     void succeed_whenReportingOnSeveralCorrectClasses() {
         List<EqualsVerifierReport> reports = EqualsVerifier.forClasses(A.class, B.class, C.class).report();
 
-        assertThat(reports.size()).isEqualTo(3);
+        assertThat(reports).hasSize(3);
         assertSuccessful(reports.get(0), A.class);
         assertSuccessful(reports.get(1), B.class);
         assertSuccessful(reports.get(2), C.class);
@@ -251,7 +251,7 @@ class MultipleTypeEqualsVerifierTest {
     void fail_whenReportingOnOneIncorrectClass() {
         List<EqualsVerifierReport> reports = EqualsVerifier.forClasses(A.class, IncorrectM.class, C.class).report();
 
-        assertThat(reports.size()).isEqualTo(3);
+        assertThat(reports).hasSize(3);
         assertSuccessful(reports.get(0), A.class);
         assertSuccessful(reports.get(2), C.class);
         assertUnsuccessful(reports.get(1), IncorrectM.class, "Subclass: equals is not final.");
@@ -262,7 +262,7 @@ class MultipleTypeEqualsVerifierTest {
         List<EqualsVerifierReport> reports =
                 EqualsVerifier.forClasses(A.class, IncorrectM.class, C.class, IncorrectN.class).report();
 
-        assertThat(reports.size()).isEqualTo(4);
+        assertThat(reports).hasSize(4);
         assertSuccessful(reports.get(0), A.class);
         assertSuccessful(reports.get(2), C.class);
         assertUnsuccessful(reports.get(1), IncorrectM.class, "Subclass: equals is not final.");

--- a/equalsverifier-core/src/test/java/nl/jqno/equalsverifier/integration/operational/OriginalStateTest.java
+++ b/equalsverifier-core/src/test/java/nl/jqno/equalsverifier/integration/operational/OriginalStateTest.java
@@ -53,7 +53,7 @@ class OriginalStateTest {
         }
         catch (AssertionError e) {
             // Make sure EV fails on a check that actually mutates fields.
-            assertThat(e.getMessage().contains("Mutability")).isTrue();
+            assertThat(e.getMessage()).contains("Mutability");
         }
         catch (Throwable ignored) {
             fail("EqualsVerifier should have failed on FailingEqualsContainerContainer with a different exception.");

--- a/equalsverifier-core/src/test/java/nl/jqno/equalsverifier/integration/operational/ReportTest.java
+++ b/equalsverifier-core/src/test/java/nl/jqno/equalsverifier/integration/operational/ReportTest.java
@@ -18,7 +18,7 @@ class ReportTest {
 
         assertThat(report.getType()).isEqualTo(FinalPoint.class);
         assertThat(report.isSuccessful()).isTrue();
-        assertThat(report.getMessage()).isEqualTo("");
+        assertThat(report.getMessage()).isEmpty();
         assertThat(report.getCause()).isNull();
     }
 

--- a/equalsverifier-core/src/test/java/nl/jqno/equalsverifier/internal/exceptions/EqualsVerifierInternalBugExceptionTest.java
+++ b/equalsverifier-core/src/test/java/nl/jqno/equalsverifier/internal/exceptions/EqualsVerifierInternalBugExceptionTest.java
@@ -60,7 +60,7 @@ class EqualsVerifierInternalBugExceptionTest {
     }
 
     private void assertNoCause() {
-        assertThat(actual.getCause()).isEqualTo(null);
+        assertThat(actual.getCause()).isNull();
     }
 
     private void assertCause(Throwable cause) {

--- a/equalsverifier-core/src/test/java/nl/jqno/equalsverifier/internal/exceptions/NoValueExceptionTest.java
+++ b/equalsverifier-core/src/test/java/nl/jqno/equalsverifier/internal/exceptions/NoValueExceptionTest.java
@@ -11,6 +11,6 @@ class NoValueExceptionTest {
     void description() {
         TypeTag tag = new TypeTag(String.class);
         NoValueException e = new NoValueException(tag);
-        assertThat(e.getDescription().contains("String")).isTrue();
+        assertThat(e.getDescription()).contains("String");
     }
 }

--- a/equalsverifier-core/src/test/java/nl/jqno/equalsverifier/internal/exceptions/RecursionExceptionTest.java
+++ b/equalsverifier-core/src/test/java/nl/jqno/equalsverifier/internal/exceptions/RecursionExceptionTest.java
@@ -20,7 +20,7 @@ class RecursionExceptionTest {
         String message = new RecursionException(stack).getDescription();
 
         for (TypeTag tag : stack) {
-            assertThat(message.contains(tag.toString())).isTrue();
+            assertThat(message).contains(tag.toString());
         }
     }
 }

--- a/equalsverifier-core/src/test/java/nl/jqno/equalsverifier/internal/instantiation/SubjectCreatorTest.java
+++ b/equalsverifier-core/src/test/java/nl/jqno/equalsverifier/internal/instantiation/SubjectCreatorTest.java
@@ -163,8 +163,7 @@ class SubjectCreatorTest {
         SomeClass original = new SomeClass(I_RED, I_RED, S_RED);
         actual = sut.copy(original);
 
-        assertThat(actual).isEqualTo(expected);
-        assertThat(actual).isNotSameAs(expected);
+        assertThat(actual).isEqualTo(expected).isNotSameAs(expected);
     }
 
     @Test

--- a/equalsverifier-core/src/test/java/nl/jqno/equalsverifier/internal/instantiation/vintage/VintageValueProviderTest.java
+++ b/equalsverifier-core/src/test/java/nl/jqno/equalsverifier/internal/instantiation/vintage/VintageValueProviderTest.java
@@ -46,7 +46,7 @@ class VintageValueProviderTest {
     @Test
     void provide() {
         Optional<Tuple<Point>> actual = vp.provide(POINT_TAG);
-        assertThat(actual.get()).isEqualTo(Tuple.of(new Point(42, 42), new Point(1337, 1337), new Point(42, 42)));
+        assertThat(actual).contains(Tuple.of(new Point(42, 42), new Point(1337, 1337), new Point(42, 42)));
     }
 
     @Test

--- a/equalsverifier-core/src/test/java/nl/jqno/equalsverifier/internal/instantiation/vintage/reflection/InPlaceObjectAccessorScramblingTest.java
+++ b/equalsverifier-core/src/test/java/nl/jqno/equalsverifier/internal/instantiation/vintage/reflection/InPlaceObjectAccessorScramblingTest.java
@@ -114,14 +114,14 @@ class InPlaceObjectAccessorScramblingTest {
     void scrambleNestedGenerics() {
         GenericContainerContainer foo = new GenericContainerContainer();
 
-        assertThat(foo.strings.ts.isEmpty()).isTrue();
-        assertThat(foo.points.ts.isEmpty()).isTrue();
+        assertThat(foo.strings.ts).isEmpty();
+        assertThat(foo.points.ts).isEmpty();
 
         doScramble(foo);
 
-        assertThat(foo.strings.ts.isEmpty()).isFalse();
+        assertThat(foo.strings.ts).isNotEmpty();
         assertThat(foo.strings.ts.get(0).getClass()).isEqualTo(String.class);
-        assertThat(foo.points.ts.isEmpty()).isFalse();
+        assertThat(foo.points.ts).isNotEmpty();
         assertThat(foo.points.ts.get(0).getClass()).isEqualTo(Point.class);
     }
 

--- a/equalsverifier-core/src/test/java/nl/jqno/equalsverifier/internal/reflection/ConditionalInstantiatorTest.java
+++ b/equalsverifier-core/src/test/java/nl/jqno/equalsverifier/internal/reflection/ConditionalInstantiatorTest.java
@@ -33,7 +33,7 @@ class ConditionalInstantiatorTest {
         ci = new ConditionalInstantiator(THIS_TYPE_DOES_NOT_EXIST);
 
         Class<?> actual = ci.resolve();
-        assertThat(actual).isEqualTo(null);
+        assertThat(actual).isNull();
     }
 
     @Test
@@ -49,7 +49,7 @@ class ConditionalInstantiatorTest {
     void nullIsReturned_whenInstantiateIsCalled_givenTypeDoesNotExist() {
         ci = new ConditionalInstantiator(THIS_TYPE_DOES_NOT_EXIST);
         Object actual = ci.instantiate(classes(String.class), objects("nope"));
-        assertThat(actual).isEqualTo(null);
+        assertThat(actual).isNull();
     }
 
     @Test
@@ -65,7 +65,7 @@ class ConditionalInstantiatorTest {
         ci = new ConditionalInstantiator("java.util.GregorianCalendar", false);
 
         Object actual = ci.instantiate(classes(int.class, int.class, int.class), objects(1999, 31, "hello"));
-        assertThat(actual).isEqualTo(null);
+        assertThat(actual).isNull();
     }
 
     @Test
@@ -81,7 +81,7 @@ class ConditionalInstantiatorTest {
     void nullIsReturned_whenFactoryIsCalled_givenTypeDoesNotExist() {
         ci = new ConditionalInstantiator(THIS_TYPE_DOES_NOT_EXIST);
         Object actual = ci.callFactory("factory", classes(String.class), objects("nope"));
-        assertThat(actual).isEqualTo(null);
+        assertThat(actual).isNull();
     }
 
     @Test
@@ -97,7 +97,7 @@ class ConditionalInstantiatorTest {
         ci = new ConditionalInstantiator("java.lang.Integer", false);
 
         Object actual = ci.callFactory("thisMethodDoesntExist", classes(int.class), objects(42));
-        assertThat(actual).isEqualTo(null);
+        assertThat(actual).isNull();
     }
 
     @Test
@@ -113,7 +113,7 @@ class ConditionalInstantiatorTest {
         ci = new ConditionalInstantiator("java.lang.Integer", false);
 
         Object actual = ci.callFactory("valueOf", classes(int.class, int.class), objects(42));
-        assertThat(actual).isEqualTo(null);
+        assertThat(actual).isNull();
     }
 
     @Test
@@ -129,7 +129,7 @@ class ConditionalInstantiatorTest {
     void nullIsReturned_whenExternalFactoryIsCalled_givenTypeDoesNotExist() {
         ci = new ConditionalInstantiator(THIS_TYPE_DOES_NOT_EXIST);
         Object actual = ci.callFactory("java.util.Collections", "emptyList", classes(), objects());
-        assertThat(actual).isEqualTo(null);
+        assertThat(actual).isNull();
     }
 
     @Test
@@ -145,7 +145,7 @@ class ConditionalInstantiatorTest {
         ci = new ConditionalInstantiator("java.util.List", false);
 
         Object actual = ci.callFactory("java.util.ThisTypeDoesNotExist", "emptyList", classes(), objects());
-        assertThat(actual).isEqualTo(null);
+        assertThat(actual).isNull();
     }
 
     @Test
@@ -162,7 +162,7 @@ class ConditionalInstantiatorTest {
         ci = new ConditionalInstantiator("java.util.List", false);
 
         Object actual = ci.callFactory("java.util.Collections", "thisMethodDoesntExist", classes(), objects());
-        assertThat(actual).isEqualTo(null);
+        assertThat(actual).isNull();
     }
 
     @Test
@@ -179,14 +179,14 @@ class ConditionalInstantiatorTest {
         ci = new ConditionalInstantiator("java.util.List", false);
 
         Object actual = ci.callFactory("java.util.Collections", "emptyList", classes(int.class), objects(42));
-        assertThat(actual).isEqualTo(null);
+        assertThat(actual).isNull();
     }
 
     @Test
     void nullIsReturned_whenReturnConstantIsCalled_givenTypeDoesNotExist() {
         ci = new ConditionalInstantiator(THIS_TYPE_DOES_NOT_EXIST);
         Object actual = ci.returnConstant("NOPE");
-        assertThat(actual).isEqualTo(null);
+        assertThat(actual).isNull();
     }
 
     @Test
@@ -210,6 +210,6 @@ class ConditionalInstantiatorTest {
         ci = new ConditionalInstantiator("java.math.BigDecimal", false);
 
         Object actual = ci.returnConstant("FORTY-TWO");
-        assertThat(actual).isEqualTo(null);
+        assertThat(actual).isNull();
     }
 }

--- a/equalsverifier-core/src/test/java/nl/jqno/equalsverifier/internal/reflection/FieldIterableTest.java
+++ b/equalsverifier-core/src/test/java/nl/jqno/equalsverifier/internal/reflection/FieldIterableTest.java
@@ -59,7 +59,7 @@ class FieldIterableTest {
     @Test
     void noFields() {
         FieldIterable iterable = FieldIterable.of(NoFields.class);
-        assertThat(iterable.iterator().hasNext()).isFalse();
+        assertThat(iterable.iterator()).isExhausted();
     }
 
     @Test
@@ -113,7 +113,7 @@ class FieldIterableTest {
     @Test
     void interfaceTest() {
         FieldIterable iterable = FieldIterable.of(Interface.class);
-        assertThat(iterable.iterator().hasNext()).isFalse();
+        assertThat(iterable.iterator()).isExhausted();
     }
 
     @Test
@@ -129,13 +129,13 @@ class FieldIterableTest {
     @Test
     void objectHasNoElements() {
         FieldIterable iterable = FieldIterable.of(Object.class);
-        assertThat(iterable.iterator().hasNext()).isFalse();
+        assertThat(iterable.iterator()).isExhausted();
     }
 
     @Test
     void ignoreSyntheticFields() {
         FieldIterable iterable = FieldIterable.of(Outer.Inner.class);
-        assertThat(iterable.iterator().hasNext()).isFalse();
+        assertThat(iterable.iterator()).isExhausted();
     }
 
     @Test
@@ -145,7 +145,7 @@ class FieldIterableTest {
         for (FieldProbe probe : iterable) {
             fields.add(probe.getField());
         }
-        assertThat(fields.size()).isEqualTo(1);
+        assertThat(fields).hasSize(1);
         assertThat(fields.get(0).getName()).isEqualTo("i");
     }
 

--- a/equalsverifier-core/src/test/java/nl/jqno/equalsverifier/internal/reflection/annotations/AnnotationCacheBuilderTest.java
+++ b/equalsverifier-core/src/test/java/nl/jqno/equalsverifier/internal/reflection/annotations/AnnotationCacheBuilderTest.java
@@ -251,8 +251,8 @@ class AnnotationCacheBuilderTest {
         assertTypeHasAnnotation(AnnotationWithValuesContainer.class, annotation);
 
         Set<String> annotations = new HashSet<>(annotation.properties.getArrayValues("annotations"));
-        assertThat(annotations.contains("javax.annotation.Nonnull")).isTrue();
-        assertThat(annotations.contains("nl.jqno.equalsverifier.testhelpers.annotations.NotNull")).isTrue();
+        assertThat(annotations).contains("javax.annotation.Nonnull");
+        assertThat(annotations).contains("nl.jqno.equalsverifier.testhelpers.annotations.NotNull");
     }
 
     @Test

--- a/equalsverifier-core/src/test/java/nl/jqno/equalsverifier/internal/util/ValidationsTest.java
+++ b/equalsverifier-core/src/test/java/nl/jqno/equalsverifier/internal/util/ValidationsTest.java
@@ -3,7 +3,7 @@ package nl.jqno.equalsverifier.internal.util;
 // CHECKSTYLE OFF: IllegalImport
 
 import static nl.jqno.equalsverifier.internal.testhelpers.Util.coverThePrivateConstructor;
-import static org.assertj.core.api.Assertions.*;
+import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.junit.jupiter.api.Assertions.assertAll;
 
 import java.util.ArrayList;


### PR DESCRIPTION
# What problem does this pull request solve?
Apply AssertJ best practices, such that you get more expressive failure messages.

# What alternatives did you consider?
Not making these changes.

# Please provide any additional information below
Ran via
```bash
mvn -U org.openrewrite.maven:rewrite-maven-plugin:run -Drewrite.recipeArtifactCoordinates=org.openrewrite.recipe:rewrite-testing-frameworks:RELEASE -Drewrite.activeRecipes=org.openrewrite.java.testing.assertj.Assertj -Drewrite.exportDatatables=true
```
As per https://docs.openrewrite.org/recipes/java/testing/assertj/assertj-best-practices