### PR TITLE
Fix/os specific file separator

### DIFF
--- a/equalsverifier-core/src/main/java/nl/jqno/equalsverifier/internal/reflection/PackageScanner.java
+++ b/equalsverifier-core/src/main/java/nl/jqno/equalsverifier/internal/reflection/PackageScanner.java
@@ -105,7 +105,8 @@ public final class PackageScanner {
     private static Class<?> fileToClass(File f, String packagePath) {
         String className = f.getName().substring(0, f.getName().length() - 6);
         String fullPath = f.getParent();
-        String packageName = fullPath.substring(fullPath.indexOf(packagePath)).replace(FileSystems.getDefault().getSeparator(), ".");
+        String packageName = fullPath.substring(fullPath.indexOf(packagePath))
+            .replace(FileSystems.getDefault().getSeparator(), ".");
         return rethrow(
             () -> Class.forName(packageName + "." + className),
             e -> "Could not resolve class " + className + ", which was found in package " + packageName);

--- a/equalsverifier-core/src/main/java/nl/jqno/equalsverifier/internal/reflection/PackageScanner.java
+++ b/equalsverifier-core/src/main/java/nl/jqno/equalsverifier/internal/reflection/PackageScanner.java
@@ -6,6 +6,7 @@ import java.io.File;
 import java.io.IOException;
 import java.net.URISyntaxException;
 import java.net.URL;
+import java.nio.file.FileSystems;
 import java.util.*;
 import java.util.jar.JarFile;
 import java.util.stream.Collectors;
@@ -32,7 +33,7 @@ public final class PackageScanner {
      * @return the classes contained in the given package.
      */
     public static List<Class<?>> getClassesIn(String packageName, PackageScanOptions options) {
-        String packagePath = packageName.replace('.', '/');
+        String packagePath = packageName.replace(".", FileSystems.getDefault().getSeparator());
 
         List<Class<?>> result = getResources(packagePath)
                 .flatMap(r -> processResource(r, packagePath, options))
@@ -104,7 +105,7 @@ public final class PackageScanner {
     private static Class<?> fileToClass(File f, String packagePath) {
         String className = f.getName().substring(0, f.getName().length() - 6);
         String fullPath = f.getParent();
-        String packageName = fullPath.substring(fullPath.indexOf(packagePath)).replace("/", ".");
+        String packageName = fullPath.substring(fullPath.indexOf(packagePath)).replace(FileSystems.getDefault().getSeparator(), ".");
         return rethrow(
             () -> Class.forName(packageName + "." + className),
             e -> "Could not resolve class " + className + ", which was found in package " + packageName);

--- a/equalsverifier-core/src/main/java/nl/jqno/equalsverifier/internal/reflection/PackageScanner.java
+++ b/equalsverifier-core/src/main/java/nl/jqno/equalsverifier/internal/reflection/PackageScanner.java
@@ -106,7 +106,7 @@ public final class PackageScanner {
         String className = f.getName().substring(0, f.getName().length() - 6);
         String fullPath = f.getParent();
         String packageName = fullPath.substring(fullPath.indexOf(packagePath))
-            .replace(FileSystems.getDefault().getSeparator(), ".");
+                .replace(FileSystems.getDefault().getSeparator(), ".");
         return rethrow(
             () -> Class.forName(packageName + "." + className),
             e -> "Could not resolve class " + className + ", which was found in package " + packageName);


### PR DESCRIPTION
# What problem does this pull request solve?
https://github.com/jqno/equalsverifier/issues/1106
Uses OS dependent file separator for package scanning

# What alternatives did you consider?
Using an old version of equalsverifier or removing it's use at all

# Please provide any additional information below
Unfortunately I could neither run the tests nor spotless:apply, because my working setup does not let me even _compile_ the project locally (some super unspecific error on compiling testhelpers) and I'm absolutely not fit with GitHub actions and don't know how to set that up in my fork. Sorry! This also means I cannot really verify that the fix even works, very unsatisfying.

If you have an easy fix for this (either local compiling with Maven 3.9.9, 3.9.11, Adoptium Java 21 - or 17 - OR getting GitHub Actions to run) I would of course try the fix.

(The error on compiling is "[ERROR] Failed to execute goal org.apache.maven.plugins:maven-compiler-plugin:3.14.0:compile (default-compile) on project equalsverifier-testhelpers: Compilation failure". Stacktrace doesn't give me any clue, debug logging is a bit overwhelming and still I don't have a clue why.)