### PR TITLE
Fixes generic enum fields

### DIFF
--- a/equalsverifier-core/src/main/java/nl/jqno/equalsverifier/internal/instantiation/prefab/BuiltinPrefabValueProvider.java
+++ b/equalsverifier-core/src/main/java/nl/jqno/equalsverifier/internal/instantiation/prefab/BuiltinPrefabValueProvider.java
@@ -18,7 +18,7 @@ import nl.jqno.equalsverifier.internal.util.PrimitiveMappers;
 public class BuiltinPrefabValueProvider implements ValueProvider {
 
     private static final Set<Class<?>> EXCEPTIONAL_GENERIC_TYPES =
-            Set.of(Class.class, Constructor.class, SynchronousQueue.class);
+            Set.of(Class.class, Constructor.class, SynchronousQueue.class, Enum.class);
 
     /** {@inheritDoc}} */
     @Override

--- a/equalsverifier-test/src/test/java/nl/jqno/equalsverifier/integration/extended_contract/GenericTypesTest.java
+++ b/equalsverifier-test/src/test/java/nl/jqno/equalsverifier/integration/extended_contract/GenericTypesTest.java
@@ -7,6 +7,7 @@ import java.util.function.Supplier;
 import nl.jqno.equalsverifier.EqualsVerifier;
 import nl.jqno.equalsverifier.Warning;
 import nl.jqno.equalsverifier_testhelpers.ExpectedException;
+import nl.jqno.equalsverifier_testhelpers.types.Color;
 import nl.jqno.equalsverifier_testhelpers.types.Point;
 import nl.jqno.equalsverifier_testhelpers.types.SparseArrays.SparseArrayEqualsContainer;
 import nl.jqno.equalsverifier_testhelpers.types.SparseArrays.SparseArrayHashCodeContainer;
@@ -122,6 +123,16 @@ class GenericTypesTest {
     @Test
     void succeed_whenFieldHasARecursiveGenericAndAWildcard() {
         EqualsVerifier.forClass(RecursiveGenericWithWildcardContainer.class).verify();
+    }
+
+    @Test
+    void succeed_whenClassHasGenericEnumField() {
+        EqualsVerifier.forClass(GenericEnumContainer.class).usingGetClass().verify();
+    }
+
+    @Test
+    void succeed_whenClassInheritsGenericEnumField() {
+        EqualsVerifier.forClass(ConcreteColorContainer.class).usingGetClass().verify();
     }
 
     static final class GenericContainerWithBuiltin {
@@ -624,6 +635,56 @@ class GenericTypesTest {
         @Override
         public int hashCode() {
             return Objects.hash(rg);
+        }
+    }
+
+    static class GenericEnumContainer<E extends Enum<E>> {
+
+        protected final E ev;
+
+        protected GenericEnumContainer(E ev) {
+            this.ev = ev;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (o == null || getClass() != o.getClass()) {
+                return false;
+            }
+            GenericEnumContainer<?> that = (GenericEnumContainer<?>) o;
+            return Objects.equals(ev, that.ev);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hashCode(ev);
+        }
+    }
+
+    static final class ConcreteColorContainer extends GenericEnumContainer<Color> {
+
+        private final int i;
+
+        public ConcreteColorContainer(Color color, int i) {
+            super(color);
+            this.i = i;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (o == null || getClass() != o.getClass()) {
+                return false;
+            }
+            if (!super.equals(o)) {
+                return false;
+            }
+            ConcreteColorContainer that = (ConcreteColorContainer) o;
+            return i == that.i;
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(super.hashCode(), i);
         }
     }
 }


### PR DESCRIPTION
Thank you for taking the time to submit a pull request and trying to improve EqualsVerifier! I appreciate it!

Before you continue, please consider the following:

- Is your PR small, such as a small bug fix with test, or a typo fix? Awesome, thank you! I'll probably merge it right away.
- Is your PR large, such as a new feature? Please consider [submitting a feature request](https://github.com/jqno/equalsverifier/issues/new) first, so we can discuss what you're about to contribute. Perhaps a different approach fits better with EqualsVerifier's code base, or maybe a similar feature already exists. I would feel really bad if you spent all that effort on a PR if it's not a good fit for the project.

# What problem does this pull request solve?

Fixes [#1122](https://github.com/jqno/equalsverifier/issues/1122)

# What alternatives did you consider?

1. Providing prefab values via `withPrefabValues()`. Users can work around this by manually providing `Enum.class` prefab values, but this shouldn't be necessary for basic enum functionality.
  
2. Modifying JPMS module configuration. This would require users to open `java.base` modules, which doesn't seem right. 

# Please provide any additional information below

# NOTE

- Please run `mvn spotless:apply` (or `just format`) to format the code before opening a PR. Otherwise, GitHub Actions will complain at you 😉.
- Mutation tests will be run by [PITest](https://pitest.org/) after opening the PR. It will post comments in the PR for each issue found. Please take a look and fix what makes sense, but don't worry about the ones that don't.
