### PR TITLE
Ignore properties not declared in the primary constructor of Kotlin data classes

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,0 +1,1 @@
+java temurin-25.0.1+8.0.LTS

--- a/docs/_manual/16-kotlin.md
+++ b/docs/_manual/16-kotlin.md
@@ -15,6 +15,20 @@ EqualsVerifier.forClass(Foo::class.java)
 
 For most simple classes and data classes, that's enough.
 
+## Data classes
+
+Since data class equality is based on primary constructor parameters, EqualsVerifier ignores other properties in such classes.
+
+For instance, in following code, `isEmpty` property is ignored:
+
+```kotlin
+data class MyDataclass(val value: String) {
+  val isEmpty = value.isEmpty()
+}
+```
+
+This behavior requires `org.jetbrains.kotlin:kotlin-reflect` library to be available, otherwise data classes are treated like any other class.
+
 ## Delegates
 
 Kotlin supports various forms of delegate fields. In a Kotlin class definition, delegates may look like this:

--- a/equalsverifier-core/src/main/java/nl/jqno/equalsverifier/internal/checkers/fieldchecks/SignificantFieldCheck.java
+++ b/equalsverifier-core/src/main/java/nl/jqno/equalsverifier/internal/checkers/fieldchecks/SignificantFieldCheck.java
@@ -11,7 +11,12 @@ import nl.jqno.equalsverifier.Warning;
 import nl.jqno.equalsverifier.internal.reflection.FieldProbe;
 import nl.jqno.equalsverifier.internal.reflection.annotations.AnnotationCache;
 import nl.jqno.equalsverifier.internal.reflection.annotations.SupportedAnnotations;
-import nl.jqno.equalsverifier.internal.util.*;
+import nl.jqno.equalsverifier.internal.reflection.kotlin.KotlinScreen;
+import nl.jqno.equalsverifier.internal.util.CachedHashCodeInitializer;
+import nl.jqno.equalsverifier.internal.util.Configuration;
+import nl.jqno.equalsverifier.internal.util.Context;
+import nl.jqno.equalsverifier.internal.util.Formatter;
+import nl.jqno.equalsverifier.internal.util.PrimitiveMappers;
 import nl.jqno.equalsverifier.internal.valueproviders.SubjectCreator;
 
 public class SignificantFieldCheck<T> implements FieldCheck<T> {
@@ -188,6 +193,13 @@ public class SignificantFieldCheck<T> implements FieldCheck<T> {
             message = """
                       Significant fields: equals does not use %%, or it is stateless.
                       Suppress Warning.SURROGATE_KEY if you want to use only the @Id or @EmbeddedId field(s).""";
+        }
+        else if (KotlinScreen.isKotlin(type)) {
+            message =
+                    """
+                    Significant fields: equals does not use %%, or it is stateless.
+                    Note: This is a Kotlin class. Import kotlin reflect in the classpath to use the adapted equalsverifier implementation.
+                    """;
         }
         else {
             message = "Significant fields: equals does not use %%, or it is stateless.";

--- a/equalsverifier-core/src/main/java/nl/jqno/equalsverifier/internal/reflection/kotlin/KotlinProbe.java
+++ b/equalsverifier-core/src/main/java/nl/jqno/equalsverifier/internal/reflection/kotlin/KotlinProbe.java
@@ -112,4 +112,19 @@ public final class KotlinProbe {
             Assert.fail(Formatter.of(msg));
         }
     }
+
+    public static boolean isDeclaredInPrimaryConstructor(Field field) {
+        Class<?> declaringClass = field.getDeclaringClass();
+        KClass<?> kType = JvmClassMappingKt.getKotlinClass(declaringClass);
+        if (kType.getConstructors().isEmpty()) {
+            return false;
+        }
+
+        KFunction<?> constructor = KClasses.getPrimaryConstructor(kType);
+        return constructor.getParameters().stream().anyMatch(p -> p.getName().equals(field.getName()));
+    }
+
+    public static <T> boolean isDataClass(Class<T> type) {
+        return JvmClassMappingKt.getKotlinClass(type).isData();
+    }
 }

--- a/equalsverifier-core/src/main/java/nl/jqno/equalsverifier/internal/util/Configuration.java
+++ b/equalsverifier-core/src/main/java/nl/jqno/equalsverifier/internal/util/Configuration.java
@@ -13,6 +13,7 @@ import nl.jqno.equalsverifier.internal.reflection.FieldIterable;
 import nl.jqno.equalsverifier.internal.reflection.FieldProbe;
 import nl.jqno.equalsverifier.internal.reflection.TypeTag;
 import nl.jqno.equalsverifier.internal.reflection.annotations.*;
+import nl.jqno.equalsverifier.internal.reflection.kotlin.KotlinProbe;
 import nl.jqno.equalsverifier.internal.reflection.kotlin.KotlinScreen;
 
 // CHECKSTYLE OFF: ParameterNumber
@@ -55,6 +56,11 @@ public record Configuration<T>(Class<T> type, TypeTag typeTag, Set<String> ignor
 
         if (isKotlin) {
             for (FieldProbe f : FieldIterable.ofKotlin(type)) {
+                if (KotlinScreen.canProbe()
+                        && KotlinProbe.isDataClass(type)
+                        && !KotlinProbe.isDeclaredInPrimaryConstructor(f.getField())) {
+                    ignoredFields.add(f.getName());
+                }
                 if (KotlinScreen.isSyntheticKotlinDelegate(f.getField())) {
                     nonnullFields.add(f.getName());
                 }

--- a/equalsverifier-test-kotlin-noreflect/src/test/kotlin/nl/jqno/equalsverifier/kotlin/KotlinDataClassTest.kt
+++ b/equalsverifier-test-kotlin-noreflect/src/test/kotlin/nl/jqno/equalsverifier/kotlin/KotlinDataClassTest.kt
@@ -16,7 +16,8 @@ class KotlinDataClassTest {
         EqualsVerifier.forClass(DataClassWithComputedProperty::class.java)
           .verify()
       }.isInstanceOf(AssertionError::class.java)
-      .hasMessageContaining("Significant fields: equals does not use isEmpty, or it is stateless")
+      .hasMessageContaining("Significant fields: equals does not use isEmpty, or it is stateless.")
+      .hasMessageContaining("Note: This is a Kotlin class. Import kotlin reflect in the classpath to use the adapted equalsverifier implementation.")
   }
 
   data class DataClassWithSecondaryConstructor(val value: String) {
@@ -30,6 +31,7 @@ class KotlinDataClassTest {
       EqualsVerifier.forClass(DataClassWithSecondaryConstructor::class.java)
         .verify()
     }.isInstanceOf(AssertionError::class.java)
-      .hasMessageContaining("Significant fields: equals does not use isEmpty, or it is stateless")
+      .hasMessageContaining("Significant fields: equals does not use isEmpty, or it is stateless.")
+      .hasMessageContaining("Note: This is a Kotlin class. Import kotlin reflect in the classpath to use the adapted equalsverifier implementation.")
   }
 }

--- a/equalsverifier-test-kotlin-noreflect/src/test/kotlin/nl/jqno/equalsverifier/kotlin/KotlinDataClassTest.kt
+++ b/equalsverifier-test-kotlin-noreflect/src/test/kotlin/nl/jqno/equalsverifier/kotlin/KotlinDataClassTest.kt
@@ -1,0 +1,35 @@
+package nl.jqno.equalsverifier.kotlin
+
+import nl.jqno.equalsverifier.EqualsVerifier
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.Test
+
+class KotlinDataClassTest {
+
+  data class DataClassWithComputedProperty(val value: String) {
+    val isEmpty = value.isEmpty()
+  }
+
+  @Test
+  fun `properties not declared in primary constructor of data classes are ignored`() {
+    assertThatThrownBy {
+        EqualsVerifier.forClass(DataClassWithComputedProperty::class.java)
+          .verify()
+      }.isInstanceOf(AssertionError::class.java)
+      .hasMessageContaining("Significant fields: equals does not use isEmpty, or it is stateless")
+  }
+
+  data class DataClassWithSecondaryConstructor(val value: String) {
+    constructor(prefix: String, isEmpty: Boolean) : this(prefix)
+    val isEmpty = value.isEmpty()
+  }
+
+  @Test
+  fun `properties declared in secondary constructor of data classes are ignored`() {
+    assertThatThrownBy {
+      EqualsVerifier.forClass(DataClassWithSecondaryConstructor::class.java)
+        .verify()
+    }.isInstanceOf(AssertionError::class.java)
+      .hasMessageContaining("Significant fields: equals does not use isEmpty, or it is stateless")
+  }
+}

--- a/equalsverifier-test-kotlin/src/test/kotlin/nl/jqno/equalsverifier/kotlin/KotlinDataClassTest.kt
+++ b/equalsverifier-test-kotlin/src/test/kotlin/nl/jqno/equalsverifier/kotlin/KotlinDataClassTest.kt
@@ -1,0 +1,28 @@
+package nl.jqno.equalsverifier.kotlin
+
+import nl.jqno.equalsverifier.EqualsVerifier
+import org.junit.jupiter.api.Test
+
+class KotlinDataClassTest {
+
+  data class DataClassWithComputedProperty(val value: String) {
+    val isEmpty = value.isEmpty()
+  }
+
+  @Test
+  fun `properties not declared in primary constructor of data classes are ignored`() {
+    EqualsVerifier.forClass(DataClassWithComputedProperty::class.java)
+      .verify()
+  }
+
+  data class DataClassWithSecondaryConstructor(val value: String) {
+    constructor(prefix: String, isEmpty: Boolean) : this(prefix)
+    val isEmpty = value.isEmpty()
+  }
+
+  @Test
+  fun `properties declared in secondary constructor of data classes are ignored`() {
+    EqualsVerifier.forClass(DataClassWithSecondaryConstructor::class.java)
+      .verify()
+  }
+}


### PR DESCRIPTION
Related discussion: #1137

# What problem does this pull request solve?

When running the following code:

```kotlin
data class MyDataClass(val value: String) {
   val isEmpty = value.isEmpty()
}

EqualsVerifier.forClass(MyDataClass::class.java).verify()
```

… it fails with `error Significant fields: equals does not use isEmpty, or it is stateless`.

This PR tries to change this behavior in order to respect [Kotlin data class contract](https://kotlinlang.org/docs/data-classes.html#properties-declared-in-the-class-body), by ignoring properties not declared in the primary constructor in equals/hashCode contract.

# Alternatives?

No

# Additional information

An issue we encountered is when kotlin reflect is not in classpath, we are unable to detect if tested class is a data class. In such case, we suggest to ignore this new behavior to not breaking existing features and tests. More over, we also are not able to print a specific error mesage which would suggest to add kotlin reflect in classpath to support data classes more properly.

We didn't add a parameter to disable this feature as suggested. We couldn't decide if it could be useful or not.

~We also added a kotlin class in `core` module to find primary constructor of a data class as you couldn't do it in java (this kotlin extension cannot be called from java).~
