### PR TITLE
fixed non-determinism in argument collection

### DIFF
--- a/equalsverifier-core/src/main/java/nl/jqno/equalsverifier/internal/instantiation/InstanceCreator.java
+++ b/equalsverifier-core/src/main/java/nl/jqno/equalsverifier/internal/instantiation/InstanceCreator.java
@@ -4,6 +4,7 @@ import java.lang.reflect.Field;
 import java.util.*;
 import java.util.function.BiConsumer;
 
+import nl.jqno.equalsverifier.internal.exceptions.ReflectionException;
 import nl.jqno.equalsverifier.internal.reflection.*;
 import nl.jqno.equalsverifier.internal.util.PrimitiveMappers;
 import org.objenesis.Objenesis;
@@ -79,7 +80,7 @@ public class InstanceCreator<T> {
                 params.add(value);
             }
             catch (NoSuchFieldException e) {
-                throw new RuntimeException(e);
+                throw new ReflectionException(e);
             }
         }
         var recordProbe = new RecordProbe<T>(type);

--- a/equalsverifier-core/src/main/java/nl/jqno/equalsverifier/internal/instantiation/InstanceCreator.java
+++ b/equalsverifier-core/src/main/java/nl/jqno/equalsverifier/internal/instantiation/InstanceCreator.java
@@ -69,7 +69,19 @@ public class InstanceCreator<T> {
 
     private T createRecordInstance(Map<Field, Object> values) {
         var params = new ArrayList<Object>();
-        traverseFields(values, (p, v) -> params.add(v));
+        for (var component : type.getRecordComponents()) {
+            try {
+                Field f = type.getDeclaredField(component.getName());
+                Object value = values.get(f);
+                if (value == null) {
+                    value = PrimitiveMappers.DEFAULT_VALUE_MAPPER.get(f.getType());
+                }
+                params.add(value);
+            }
+            catch (NoSuchFieldException e) {
+                throw new RuntimeException(e);
+            }
+        }
         var recordProbe = new RecordProbe<T>(type);
         return recordProbe.callRecordConstructor(params);
     }


### PR DESCRIPTION
# What problem does this pull request solve?
Resolves Issue #1160 

# Fix
Fix non-determinism by using `type.getRecordComponents()` instead of relying on `getDeclaredFields`. The former guarantees declaration order in record header ([Reference](https://docs.oracle.com/en/java/javase/16/docs/api/java.base/java/lang/Class.html#getRecordComponents())). Then we convert the returned RecordComponent into fields.

