### PR TITLE
Restore support of multiple Pattern based ScanOpts

### DIFF
--- a/equalsverifier-core/src/main/java/nl/jqno/equalsverifier/internal/reflection/PackageScanOptions.java
+++ b/equalsverifier-core/src/main/java/nl/jqno/equalsverifier/internal/reflection/PackageScanOptions.java
@@ -65,6 +65,8 @@ public class PackageScanOptions {
 
     public static PackageScanOptions process(ScanOption... options) {
         PackageScanOptions result = new PackageScanOptions();
+        boolean predicateDefined = false;
+
         for (ScanOption option : options) {
             if (option.equals(O.RECURSIVE)) {
                 result.scanRecursively = true;
@@ -79,7 +81,13 @@ public class PackageScanOptions {
                 result.exceptClasses.addAll(ec.types);
             }
             if (option instanceof ExclusionPredicate ep) {
-                result.exclusionPredicate = ep.exclusionPredicate;
+                if (predicateDefined) {
+                    result.exclusionPredicate = result.exclusionPredicate.or(ep.exclusionPredicate);
+                }
+                else {
+                    result.exclusionPredicate = ep.exclusionPredicate;
+                    predicateDefined = true;
+                }
             }
         }
         return result;

--- a/equalsverifier-core/src/main/java/nl/jqno/equalsverifier/internal/reflection/PackageScanner.java
+++ b/equalsverifier-core/src/main/java/nl/jqno/equalsverifier/internal/reflection/PackageScanner.java
@@ -44,6 +44,7 @@ public final class PackageScanner {
                 .filter(
                     c -> options.mustExtend() == null
                             || (options.mustExtend().isAssignableFrom(c) && !options.mustExtend().equals(c)))
+                .distinct()
                 .collect(Collectors.toList()); // Need a mutable List for the next validations
 
         Validations.validateTypesAreKnown(options.exceptClasses(), result);

--- a/equalsverifier-core/src/test/java/nl/jqno/equalsverifier/internal/reflection/PackageScannerTest.java
+++ b/equalsverifier-core/src/test/java/nl/jqno/equalsverifier/internal/reflection/PackageScannerTest.java
@@ -83,11 +83,14 @@ class PackageScannerTest {
 
     @Test
     void happyPathExceptPredicate() {
-        opts = PackageScanOptions.process(ScanOption.except(c -> c.getSimpleName().endsWith("B")));
+        opts = PackageScanOptions
+                .process(
+                    ScanOption.except(c -> c.getSimpleName().endsWith("B")),
+                    ScanOption.except(c -> c.getSimpleName().endsWith("C")));
         List<Class<?>> classes =
                 PackageScanner.getClassesIn("nl.jqno.equalsverifier.testhelpers.packages.correct", opts);
         sort(classes);
-        assertThat(classes).isEqualTo(Arrays.asList(A.class, C.class));
+        assertThat(classes).isEqualTo(List.of(A.class));
     }
 
     @Test


### PR DESCRIPTION
Back in the 3.x and earlier series of EqualsVerifier, one could call `.except(Pattern)` multiple times before verifying classes in a package.

Unfortunately, this functionality was lost in the transition to ScanOpts and was only recently discovered.

This commit restores the ability to repetitively list pattern-based exceptions by tracking whether we have already applied a pattern, and optionally the existing pattern, with each subsequent one.

As part of this change, the PackageScannerTest has been altered to list two exceptions and verify accordingly.

Oddly, as part of this, I had to add a `distinct` call to PackageScanner as the discovered classes appeared to include duplicates now, tho I'm not sure how/why.

Fixes issue #1167
