### PR TITLE
docs: Add Javadoc to SuperA class

### DIFF
--- a/equalsverifier-core/src/test/java/nl/jqno/equalsverifier/testhelpers/packages/subclasses/SuperA.java
+++ b/equalsverifier-core/src/test/java/nl/jqno/equalsverifier/testhelpers/packages/subclasses/SuperA.java
@@ -1,3 +1,6 @@
 package nl.jqno.equalsverifier.testhelpers.packages.subclasses;
 
+/**
+ * A test helper class for subclass scenarios in EqualsVerifier tests.
+ */
 public class SuperA {}


### PR DESCRIPTION
### 问题背景
SuperA类是一个测试辅助类，用于EqualsVerifier测试中的子类场景，但缺少Javadoc文档。这降低了代码的可读性和可维护性，可能使其他开发者难以快速理解其用途。

### 修改内容
- 在SuperA类上添加了Javadoc注释，内容为 "A test helper class for subclass scenarios in EqualsVerifier tests."
- 这样改可以提升代码质量，通过提供清晰的文档说明，帮助开发者更好地理解和维护测试代码。
- 修改仅限于文档，没有改变任何功能代码或API，因此不会影响现有行为。

### 验证方式
- 现有测试应继续通过，因为只添加了注释，没有修改任何逻辑代码。
- 没有添加新测试，但可以通过代码审查确认注释的准确性和完整性。
- 手动检查文件，确保注释已正确添加。

### 其他信息
- 没有引入breaking changes。
- 不需要更新额外文档。
- 没有已知的限制。