### PR TITLE
Remove obsolete JavadocStyle check

### DIFF
--- a/build/checkstyle-config.xml
+++ b/build/checkstyle-config.xml
@@ -74,7 +74,7 @@
         <module name="JavadocMethod">
             <property name="accessModifiers" value="public"/>
         </module>
-        <module name="JavadocStyle"/>
+        <module name="SummaryJavadoc"/>
         <module name="JavadocTagContinuationIndentation"/>
         <module name="JavaNCSS"/>
         <module name="LocalFinalVariableName"/>

--- a/equalsverifier-test/src/test/java/nl/jqno/equalsverifier/integration/inheritance/SubclassTest.java
+++ b/equalsverifier-test/src/test/java/nl/jqno/equalsverifier/integration/inheritance/SubclassTest.java
@@ -9,7 +9,7 @@ import nl.jqno.equalsverifier_testhelpers.types.*;
 import org.junit.jupiter.api.Test;
 
 /**
- * Tests, among other things, the following approaches to inheritance with added fields:
+ * Tests, among other things, the following approaches to inheritance with added fields.
  *
  * <p>
  * 1. "blindly equals", as described by Tal Cohen in Dr. Dobb's Journal, May 2002. See also


### PR DESCRIPTION
Replaces the obsolete `JavadocStyle` check because it is being removed from Checkstyle in checkstyle/checkstyle#20582.

Adds `SummaryJavadoc` to keep Javadoc summary validation and fixes the single violation it reported.