### PR TITLE
Add prefab values for LinkedHashSet

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Prefab values for `LinkedHashSet` so fields of that type no longer require `--add-opens java.base/java.util` or `withPrefabValues`. ([Issue 1231](https://github.com/jqno/equalsverifier/issues/1231))
+- Adds prefab values for `java.util.LinkedHashSet`. ([Issue 1231](https://github.com/jqno/equalsverifier/issues/1231))
 
 ## [4.5] - 2026-04-17
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Prefab values for `LinkedHashSet` so fields of that type no longer require `--add-opens java.base/java.util` or `withPrefabValues`. ([Issue 1231](https://github.com/jqno/equalsverifier/issues/1231))
+
 ## [4.5] - 2026-04-17
 
 ### Added

--- a/equalsverifier-core/src/main/java/nl/jqno/equalsverifier/internal/valueproviders/prefab/GenericJavaUtilValueSupplier.java
+++ b/equalsverifier-core/src/main/java/nl/jqno/equalsverifier/internal/valueproviders/prefab/GenericJavaUtilValueSupplier.java
@@ -102,6 +102,9 @@ public class GenericJavaUtilValueSupplier<T> extends GenericValueSupplier<T> {
         if (is(HashSet.class)) {
             return collection(HashSet::new);
         }
+        if (is(LinkedHashSet.class)) {
+            return collection(LinkedHashSet::new);
+        }
         if (is(TreeSet.class)) {
             return collection(() -> new TreeSet<>(OBJECT_COMPARATOR));
         }

--- a/equalsverifier-test/src/test/java/nl/jqno/equalsverifier/integration/extended_contract/JavaApiClassesTest.java
+++ b/equalsverifier-test/src/test/java/nl/jqno/equalsverifier/integration/extended_contract/JavaApiClassesTest.java
@@ -200,6 +200,7 @@ class JavaApiClassesTest {
         private final NavigableSet<String> navigableSet;
         private final CopyOnWriteArraySet<String> copyOnWriteArraySet;
         private final HashSet<String> hashSet;
+        private final LinkedHashSet<String> linkedHashSet;
         private final TreeSet<String> treeSet;
         private final EnumSet<TypeHelper.SimpleEnum> enumSet;
 
@@ -209,6 +210,7 @@ class JavaApiClassesTest {
                 NavigableSet<String> navigableSet,
                 CopyOnWriteArraySet<String> copyOnWriteArraySet,
                 HashSet<String> hashSet,
+                LinkedHashSet<String> linkedHashSet,
                 TreeSet<String> treeSet,
                 EnumSet<TypeHelper.SimpleEnum> enumSet) {
             this.set = set;
@@ -216,6 +218,7 @@ class JavaApiClassesTest {
             this.navigableSet = navigableSet;
             this.copyOnWriteArraySet = copyOnWriteArraySet;
             this.hashSet = hashSet;
+            this.linkedHashSet = linkedHashSet;
             this.treeSet = treeSet;
             this.enumSet = enumSet;
         }
@@ -231,6 +234,7 @@ class JavaApiClassesTest {
                     && Objects.equals(navigableSet, other.navigableSet)
                     && Objects.equals(copyOnWriteArraySet, other.copyOnWriteArraySet)
                     && Objects.equals(hashSet, other.hashSet)
+                    && Objects.equals(linkedHashSet, other.linkedHashSet)
                     && Objects.equals(treeSet, other.treeSet)
                     && Objects.equals(enumSet, other.enumSet);
         }
@@ -238,9 +242,10 @@ class JavaApiClassesTest {
         @Override
         public int hashCode() {
             callIterator(set, sortedSet, navigableSet);
-            callIterator(copyOnWriteArraySet, hashSet, treeSet);
+            callIterator(copyOnWriteArraySet, hashSet, linkedHashSet, treeSet);
             callIterator(enumSet);
-            return Objects.hash(set, sortedSet, navigableSet, copyOnWriteArraySet, hashSet, treeSet, enumSet);
+            return Objects.hash(
+                    set, sortedSet, navigableSet, copyOnWriteArraySet, hashSet, linkedHashSet, treeSet, enumSet);
         }
     }
 

--- a/equalsverifier-test/src/test/java/nl/jqno/equalsverifier/integration/extended_contract/JavaApiClassesTest.java
+++ b/equalsverifier-test/src/test/java/nl/jqno/equalsverifier/integration/extended_contract/JavaApiClassesTest.java
@@ -244,8 +244,8 @@ class JavaApiClassesTest {
             callIterator(set, sortedSet, navigableSet);
             callIterator(copyOnWriteArraySet, hashSet, linkedHashSet, treeSet);
             callIterator(enumSet);
-            return Objects.hash(
-                    set, sortedSet, navigableSet, copyOnWriteArraySet, hashSet, linkedHashSet, treeSet, enumSet);
+            return Objects
+                    .hash(set, sortedSet, navigableSet, copyOnWriteArraySet, hashSet, linkedHashSet, treeSet, enumSet);
         }
     }
 


### PR DESCRIPTION
## Summary
- Add prefab values for `java.util.LinkedHashSet`.
- Cover it in `JavaApiClassesTest.SetContainer`.

Fixes #1231

## Test plan
- [x] `JavaApiClassesTest#succeed_whenClassContainsASet`
- [x] `mvn -pl equalsverifier-core,equalsverifier-test -am test -DdisableStaticAnalysis`
- [x] `mvn spotless:check`